### PR TITLE
Avoid using Flow.stateIn in StoreFlow.map

### DIFF
--- a/core/src/commonMain/kotlin/com/episode6/redux/ext.kt
+++ b/core/src/commonMain/kotlin/com/episode6/redux/ext.kt
@@ -5,10 +5,12 @@ import kotlinx.coroutines.flow.*
 
 fun <T, R> StoreFlow<T>.mapStore(mapper: (T)->R): StoreFlow<R> {
   val newInitialValue = mapper(initialValue)
-  val flow = map { mapper(it) }.stateIn(scope, SharingStarted.WhileSubscribed(), newInitialValue)
-  return object : StoreFlow<R>, StateFlow<R> by flow {
+  val newFlow = map { mapper(it) }.distinctUntilChanged()
+  return object : StoreFlow<R>, Flow<R> by newFlow {
     override val scope: CoroutineScope get() = this@mapStore.scope
     override val initialValue: R get() = newInitialValue
     override fun dispatch(action: Action) = this@mapStore.dispatch(action)
+    override val replayCache: List<R> get() = this@mapStore.replayCache.map(mapper)
+    override val value: R get() = mapper(this@mapStore.value)
   }
 }

--- a/core/src/commonTest/kotlin/com/episode6/redux/TestMapStore.kt
+++ b/core/src/commonTest/kotlin/com/episode6/redux/TestMapStore.kt
@@ -32,10 +32,13 @@ class TestMapStore {
   }
 
   @Test fun testDispatchValueChanged() = runFlowTest {
-    val store: StoreFlow<Boolean> = stopLightStore().mapStore { it.redLight }
+    val backingStore = stopLightStore()
+    val store: StoreFlow<Boolean> = backingStore.mapStore { it.redLight }
 
     store.test {
       store.dispatch(SetRedLightOn(false))
+      store.dispatch(SetRedLightOn(false)) // dupes all ignored
+      backingStore.dispatch(SetRedLightOn(false))
 
       assertThat(values).containsExactly(true, false)
     }

--- a/core/src/commonTest/kotlin/com/episode6/redux/TestMapStore.kt
+++ b/core/src/commonTest/kotlin/com/episode6/redux/TestMapStore.kt
@@ -8,9 +8,7 @@ import assertk.assertions.index
 import assertk.assertions.isTrue
 import com.episode6.redux.testsupport.runFlowTest
 import com.episode6.redux.testsupport.runTest
-import com.episode6.redux.testsupport.stoplight.SetRedLightOn
-import com.episode6.redux.testsupport.stoplight.StopLightState
-import com.episode6.redux.testsupport.stoplight.createStopLightStore
+import com.episode6.redux.testsupport.stoplight.*
 import kotlinx.coroutines.CoroutineScope
 import kotlin.test.Test
 
@@ -41,6 +39,25 @@ class TestMapStore {
       backingStore.dispatch(SetRedLightOn(false))
 
       assertThat(values).containsExactly(true, false)
+    }
+  }
+
+  @Test fun testDispatchValueChanged_testCollector() = runFlowTest {
+    val backingStore = stopLightStore()
+    val store: StoreFlow<Boolean> = backingStore.mapStore { it.redLight }
+    val backingStoreCollector = backingStore.testCollector()
+    val storeCollector = store.testCollector()
+
+    store.dispatch(SetRedLightOn(false))
+    store.dispatch(SetRedLightOn(false)) // dupes all ignored
+    backingStore.dispatch(SetRedLightOn(false))
+
+    // verify both stores have same values and same number of values
+    assertThat(storeCollector.values).containsExactly(true, false)
+    assertThat(backingStoreCollector.values).all {
+      hasSize(2)
+      index(0).hasDefaultLights()
+      index(1).hasLights()
     }
   }
 }


### PR DESCRIPTION
By using `Flow.stateIn` in our `StoreFlow.mapStore` method, we're creating this weird new StateFlow that doesn't match the properties of the original (for example, getting the value while a collector isn't subscribed would be invalid).

Instead let's just forward the StateFlow methods to the original delegate StoreFlow