### PR TITLE
Add a subscriber aware store flow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,5 +13,6 @@ rootProject.name = "redux-store-flow"
 include(
   ":core",
   ":side-effects",
+  ":subscriber-aware",
   ":test-support",
 )

--- a/subscriber-aware/build.gradle.kts
+++ b/subscriber-aware/build.gradle.kts
@@ -1,0 +1,20 @@
+description = "Subscriber-Aware version of StoreFlow"
+
+plugins {
+  id("config-multi-deploy")
+}
+
+kotlin {
+  sourceSets {
+    val commonMain by getting {
+      dependencies {
+        api(project(":core"))
+      }
+    }
+    val commonTest by getting {
+      dependencies {
+        implementation(project(":test-support"))
+      }
+    }
+  }
+}

--- a/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
+++ b/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
@@ -27,9 +27,9 @@ data class SubscriberStatusChanged(val subscribersActive: Boolean = false) : Act
   val store = StoreFlow(scope = scope, initialValue = initialValue, reducer = reducer, middlewares = middlewares)
 
   val flow = store
-    .drop(1) // since we have to emit onStart, drop the store's first emission
     .onStart { store.dispatch(SubscriberStatusChanged(true)) }
     .onCompletion { store.dispatch(SubscriberStatusChanged(false)) }
+    .drop(1) // since we have to emit onStart, drop the store's first emission
     .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0) // replay = stale emissions when SharingStarted.WhileSubscribed is used
     .onStart { emit(store.state) } // replacement for replay
 

--- a/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
+++ b/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
@@ -17,17 +17,21 @@ data class SubscriberStatusChanged(val subscribersActive: Boolean = false) : Act
  * collecting from it. The actions will fire when the first subscriber starts and the last subscriber
  * stops collecting.
  */
-@Suppress("FunctionName") fun <State: Any?> SubscriberAwareStoreFlow(
+@Suppress("FunctionName") fun <State : Any?> SubscriberAwareStoreFlow(
   scope: CoroutineScope,
   initialValue: State,
   reducer: Reducer<State>,
   middlewares: List<Middleware<State>> = emptyList(),
 ): StoreFlow<State> {
+
   val store = StoreFlow(scope = scope, initialValue = initialValue, reducer = reducer, middlewares = middlewares)
+
   val flow = store
+    .drop(1) // since we have to emit onStart, drop the store's first emission
     .onStart { store.dispatch(SubscriberStatusChanged(true)) }
-    .onCompletion { store.dispatch(SubscriberStatusChanged(false))  } 
-    .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 1)
+    .onCompletion { store.dispatch(SubscriberStatusChanged(false)) }
+    .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0) // replay = stale emissions when SharingStarted.WhileSubscribed is used
+    .onStart { emit(store.state) } // replacement for replay
 
   return object : StoreFlow<State>, Flow<State> by flow {
     override val initialState: State get() = store.initialState

--- a/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
+++ b/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
@@ -1,0 +1,29 @@
+package com.episode6.redux.subscriberaware
+
+import com.episode6.redux.Action
+import com.episode6.redux.Middleware
+import com.episode6.redux.Reducer
+import com.episode6.redux.StoreFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.*
+
+data class SubscriberStatusChanged(val subscribersActive: Boolean = false) : Action
+
+fun <State: Any?> SubscriberAwareStoreFlow(
+  scope: CoroutineScope,
+  initialValue: State,
+  reducer: Reducer<State>,
+  middlewares: List<Middleware<State>> = emptyList(),
+): StoreFlow<State> {
+  val store = StoreFlow(scope = scope, initialValue = initialValue, reducer = reducer, middlewares = middlewares)
+  val flow = store
+    .onStart { store.dispatch(SubscriberStatusChanged(true)) }
+    .onCompletion { store.dispatch(SubscriberStatusChanged(false))  }
+    .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 1)
+
+  return object : StoreFlow<State>, Flow<State> by flow {
+    override val initialState: State get() = store.initialState
+    override val state: State get() = store.state
+    override fun dispatch(action: Action) = store.dispatch(action)
+  }
+}

--- a/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
+++ b/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
@@ -7,9 +7,17 @@ import com.episode6.redux.StoreFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
 
+/**
+ * An [Action] that is dispatched to a [StoreFlow] that is created with [SubscriberAwareStoreFlow]
+ */
 data class SubscriberStatusChanged(val subscribersActive: Boolean = false) : Action
 
-fun <State: Any?> SubscriberAwareStoreFlow(
+/**
+ * Creates a [StoreFlow] that dispatches [SubscriberStatusChanged] when subscribers start or stop
+ * collecting from it. The actions will fire when the first subscriber starts and the last subscriber
+ * stops collecting.
+ */
+@Suppress("FunctionName") fun <State: Any?> SubscriberAwareStoreFlow(
   scope: CoroutineScope,
   initialValue: State,
   reducer: Reducer<State>,
@@ -18,7 +26,7 @@ fun <State: Any?> SubscriberAwareStoreFlow(
   val store = StoreFlow(scope = scope, initialValue = initialValue, reducer = reducer, middlewares = middlewares)
   val flow = store
     .onStart { store.dispatch(SubscriberStatusChanged(true)) }
-    .onCompletion { store.dispatch(SubscriberStatusChanged(false))  }
+    .onCompletion { store.dispatch(SubscriberStatusChanged(false))  } 
     .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 1)
 
   return object : StoreFlow<State>, Flow<State> by flow {

--- a/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
+++ b/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
@@ -1,0 +1,10 @@
+package com.episode6.redux.subscriberaware
+
+import kotlin.test.Test
+
+class SubscriberAwareStoreFlowTest {
+
+  @Test fun placeholder() {
+
+  }
+}

--- a/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
+++ b/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
@@ -6,9 +6,9 @@ import assertk.assertions.*
 import com.episode6.redux.Action
 import com.episode6.redux.Middleware
 import com.episode6.redux.StoreFlow
+import com.episode6.redux.testsupport.lastElement
 import com.episode6.redux.testsupport.runFlowTest
-import com.episode6.redux.testsupport.stoplight.StopLightState
-import com.episode6.redux.testsupport.stoplight.reduce
+import com.episode6.redux.testsupport.stoplight.*
 import kotlinx.coroutines.CoroutineScope
 import kotlin.test.Test
 
@@ -53,6 +53,69 @@ class SubscriberAwareStoreFlowTest {
       hasSize(2)
       index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
       index(1).isEqualTo(SubscriberStatusChanged(subscribersActive = false))
+    }
+  }
+
+  @Test fun testMultipleSubscribers() = runFlowTest {
+    val store = stopLightStore()
+
+    val collector1 = store.testCollector()
+    val collector2 = store.testCollector()
+
+    assertThat(actions).all {
+      hasSize(1)
+      index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
+    }
+  }
+
+  @Test fun testDanglingSubscriber() = runFlowTest {
+    val store = stopLightStore()
+
+    val collector1 = store.testCollector()
+    val collector2 = store.testCollector()
+    collector1.stopCollecting()
+
+    assertThat(actions).all {
+      hasSize(1)
+      index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
+    }
+  }
+
+  @Test fun testMultipleSubscribers_unsubscribe() = runFlowTest {
+    val store = stopLightStore()
+
+    val collector1 = store.testCollector()
+    val collector2 = store.testCollector()
+    collector1.stopCollecting()
+    collector2.stopCollecting()
+
+    assertThat(actions).all {
+      hasSize(2)
+      index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
+      index(1).isEqualTo(SubscriberStatusChanged(subscribersActive = false))
+    }
+  }
+
+  @Test fun testDoesNotEmitStaleState() = runFlowTest {
+    val store = stopLightStore()
+
+    val collector = store.testCollector()
+    store.dispatch(SetRedLightOn(false))
+    assertThat(collector.values).all {
+      hasSize(2)
+      index(0).hasDefaultLights()
+      index(1).hasLights()
+    }
+
+    collector.stopCollecting()
+    store.dispatch(SetGreenLightOn(true))
+    assertThat(collector.values).hasSize(2) // no change because not collecting
+    assertThat(store.state).hasLights(green = true)
+
+    collector.startCollecting()
+    assertThat(collector.values).all {
+      hasSize(3)
+      lastElement().hasLights(green = true)
     }
   }
 }

--- a/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
+++ b/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
@@ -41,6 +41,7 @@ class SubscriberAwareStoreFlowTest {
 
     store.test {
       assertThat(actions).containsExactly(SubscriberStatusChanged(subscribersActive = true))
+      assertThat(values).isNotEmpty()
     }
   }
 

--- a/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
+++ b/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
@@ -66,6 +66,8 @@ class SubscriberAwareStoreFlowTest {
       hasSize(1)
       index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
     }
+    assertThat(collector1.values).isNotEmpty()
+    assertThat(collector2.values).isNotEmpty()
   }
 
   @Test fun testDanglingSubscriber() = runFlowTest {
@@ -79,6 +81,8 @@ class SubscriberAwareStoreFlowTest {
       hasSize(1)
       index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
     }
+    assertThat(collector1.values).isNotEmpty()
+    assertThat(collector2.values).isNotEmpty()
   }
 
   @Test fun testMultipleSubscribers_unsubscribe() = runFlowTest {
@@ -94,6 +98,8 @@ class SubscriberAwareStoreFlowTest {
       index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
       index(1).isEqualTo(SubscriberStatusChanged(subscribersActive = false))
     }
+    assertThat(collector1.values).isNotEmpty()
+    assertThat(collector2.values).isNotEmpty()
   }
 
   @Test fun testDoesNotEmitStaleState() = runFlowTest {

--- a/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
+++ b/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
@@ -1,10 +1,58 @@
 package com.episode6.redux.subscriberaware
 
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.*
+import com.episode6.redux.Action
+import com.episode6.redux.Middleware
+import com.episode6.redux.StoreFlow
+import com.episode6.redux.testsupport.runFlowTest
+import com.episode6.redux.testsupport.stoplight.StopLightState
+import com.episode6.redux.testsupport.stoplight.reduce
+import kotlinx.coroutines.CoroutineScope
 import kotlin.test.Test
 
 class SubscriberAwareStoreFlowTest {
 
-  @Test fun placeholder() {
+  val actions = mutableListOf<Action>()
+  val middleware = Middleware<StopLightState> { _, next ->
+    {
+      actions += it
+      next(it)
+    }
+  }
 
+  private fun CoroutineScope.stopLightStore(): StoreFlow<StopLightState> = SubscriberAwareStoreFlow(
+    scope = this,
+    initialValue = StopLightState(),
+    reducer = StopLightState::reduce,
+    middlewares = listOf(middleware)
+  )
+
+  @Suppress("UNUSED_VARIABLE")
+  @Test fun testNoInitialAction() = runFlowTest {
+    val store = stopLightStore()
+
+    assertThat(actions).isEmpty()
+  }
+
+  @Test fun testSubscribe() = runFlowTest {
+    val store = stopLightStore()
+
+    store.test {
+      assertThat(actions).containsExactly(SubscriberStatusChanged(subscribersActive = true))
+    }
+  }
+
+  @Test fun testUnSubscribe() = runFlowTest {
+    val store = stopLightStore()
+
+    store.testCollector().stopCollecting()
+
+    assertThat(actions).all {
+      hasSize(2)
+      index(0).isEqualTo(SubscriberStatusChanged(subscribersActive = true))
+      index(1).isEqualTo(SubscriberStatusChanged(subscribersActive = false))
+    }
   }
 }


### PR DESCRIPTION
The `SubscriberAwareStoreFlow` dispatches `SubscriberStatusChanged` actions when first subscriber starts and last subscriber stops collecting.