### PR TITLE
Avoid race conditions in SubscriberAwareStoreFlow

### DIFF
--- a/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
+++ b/subscriber-aware/src/commonMain/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlow.kt
@@ -29,9 +29,9 @@ data class SubscriberStatusChanged(val subscribersActive: Boolean = false) : Act
   val flow = store
     .onStart { store.dispatch(SubscriberStatusChanged(true)) }
     .onCompletion { store.dispatch(SubscriberStatusChanged(false)) }
-    .drop(1) // since we have to emit onStart, drop the store's first emission
     .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0) // replay = stale emissions when SharingStarted.WhileSubscribed is used
     .onStart { emit(store.state) } // replacement for replay
+    .distinctUntilChanged()
 
   return object : StoreFlow<State>, Flow<State> by flow {
     override val initialState: State get() = store.initialState


### PR DESCRIPTION
Instead of dropping 1 in a subscriber aware StoreFlow, use distinctUntilChanged to avoid the duplicate emission.