### PR TITLE
Refactor test-support module and split it in two

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     }
     val commonTest by getting {
       dependencies {
-        implementation(project(":test-support"))
+        implementation(project(":test-support:internal"))
       }
     }
     val jvmTest by getting {

--- a/core/src/commonTest/kotlin/com/episode6/redux/NoMiddlewareTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/redux/NoMiddlewareTest.kt
@@ -6,8 +6,8 @@ import app.cash.turbine.test
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.index
-import com.episode6.redux.testsupport.awaitItems
-import com.episode6.redux.testsupport.stoplight.*
+import com.episode6.redux.testsupport.internal.awaitItems
+import com.episode6.redux.testsupport.internal.stoplight.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.Test
 

--- a/core/src/commonTest/kotlin/com/episode6/redux/TestMapStore.kt
+++ b/core/src/commonTest/kotlin/com/episode6/redux/TestMapStore.kt
@@ -9,11 +9,11 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.index
 import assertk.assertions.isTrue
-import com.episode6.redux.testsupport.awaitItems
-import com.episode6.redux.testsupport.stoplight.SetRedLightOn
-import com.episode6.redux.testsupport.stoplight.hasDefaultLights
-import com.episode6.redux.testsupport.stoplight.hasLights
-import com.episode6.redux.testsupport.stoplight.stopLightStoreTest
+import com.episode6.redux.testsupport.internal.awaitItems
+import com.episode6.redux.testsupport.internal.stoplight.SetRedLightOn
+import com.episode6.redux.testsupport.internal.stoplight.hasDefaultLights
+import com.episode6.redux.testsupport.internal.stoplight.hasLights
+import com.episode6.redux.testsupport.internal.stoplight.stopLightStoreTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.Test
 

--- a/core/src/jvmTest/kotlin/com/episode6/redux/BeforeAndAfterMiddlewareTest.kt
+++ b/core/src/jvmTest/kotlin/com/episode6/redux/BeforeAndAfterMiddlewareTest.kt
@@ -5,7 +5,7 @@ package com.episode6.redux
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.redux.testsupport.stoplight.*
+import com.episode6.redux.testsupport.internal.stoplight.*
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,5 +14,7 @@ include(
   ":core",
   ":side-effects",
   ":subscriber-aware",
+
   ":test-support",
+  ":test-support:internal",
 )

--- a/side-effects/build.gradle.kts
+++ b/side-effects/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     }
     val commonTest by getting {
       dependencies {
-        implementation(project(":test-support"))
+        implementation(project(":test-support:internal"))
       }
     }
   }

--- a/side-effects/src/commonTest/kotlin/com/episode6/redux/sideeffects/SideEffectMiddlewareTest.kt
+++ b/side-effects/src/commonTest/kotlin/com/episode6/redux/sideeffects/SideEffectMiddlewareTest.kt
@@ -7,8 +7,11 @@ import assertk.all
 import assertk.assertThat
 import com.episode6.redux.Action
 import com.episode6.redux.StoreFlow
-import com.episode6.redux.testsupport.*
-import com.episode6.redux.testsupport.stoplight.*
+import com.episode6.redux.testsupport.internal.TimingController
+import com.episode6.redux.testsupport.internal.awaitItems
+import com.episode6.redux.testsupport.internal.lastElement
+import com.episode6.redux.testsupport.internal.stoplight.*
+import com.episode6.redux.testsupport.runStoreTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.FlowCollector

--- a/subscriber-aware/build.gradle.kts
+++ b/subscriber-aware/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     }
     val commonTest by getting {
       dependencies {
-        implementation(project(":test-support"))
+        implementation(project(":test-support:internal"))
       }
     }
   }

--- a/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
+++ b/subscriber-aware/src/commonTest/kotlin/com/episode6/redux/subscriberaware/SubscriberAwareStoreFlowTest.kt
@@ -9,13 +9,11 @@ import assertk.assertThat
 import assertk.assertions.*
 import com.episode6.redux.Action
 import com.episode6.redux.Middleware
-import com.episode6.redux.StoreFlow
-import com.episode6.redux.testsupport.awaitItems
+import com.episode6.redux.testsupport.internal.awaitItems
+import com.episode6.redux.testsupport.internal.stoplight.*
 import com.episode6.redux.testsupport.runStoreTest
-import com.episode6.redux.testsupport.stoplight.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
 import kotlin.test.Test
 
 class SubscriberAwareStoreFlowTest {

--- a/test-support/build.gradle.kts
+++ b/test-support/build.gradle.kts
@@ -10,6 +10,10 @@ kotlin {
       dependencies {
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.coroutines.test)
+      }
+    }
+    val commonTest by getting {
+      dependencies {
         implementation(project(":core"))
       }
     }

--- a/test-support/build.gradle.kts
+++ b/test-support/build.gradle.kts
@@ -4,17 +4,12 @@ plugins {
   id("config-multi")
 }
 
-// assertK doesn't support windows builds yet, simply disabling the task results doesn't solve the issue
-rootProject.gradle.startParameter.excludedTaskNames.add(":test-support:compileKotlinMingwX64")
-
 kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        api(libs.kotlinx.coroutines.core)
-        api(libs.kotlinx.coroutines.test)
-        api(libs.assertk.core)
-        api(libs.turbine)
+        implementation(libs.kotlinx.coroutines.core)
+        implementation(libs.kotlinx.coroutines.test)
         implementation(project(":core"))
       }
     }

--- a/test-support/internal/build.gradle.kts
+++ b/test-support/internal/build.gradle.kts
@@ -1,0 +1,24 @@
+description = "Core implementation of Redux StoreFlow"
+
+plugins {
+  id("config-multi")
+}
+
+// assertK doesn't support windows builds yet, simply disabling the task results doesn't solve the issue
+rootProject.gradle.startParameter.excludedTaskNames.add(":test-support:internal:compileKotlinMingwX64")
+
+kotlin {
+  sourceSets {
+    val commonMain by getting {
+      dependencies {
+        api(libs.kotlinx.coroutines.core)
+        api(libs.kotlinx.coroutines.test)
+        api(libs.assertk.core)
+        api(libs.turbine)
+        api(project(":test-support"))
+        implementation(project(":core"))
+      }
+    }
+  }
+}
+

--- a/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/AssertExt.kt
+++ b/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/AssertExt.kt
@@ -1,4 +1,4 @@
-package com.episode6.redux.testsupport
+package com.episode6.redux.testsupport.internal
 
 import assertk.Assert
 import assertk.assertions.support.appendName

--- a/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/TimingController.kt
+++ b/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/TimingController.kt
@@ -1,4 +1,4 @@
-package com.episode6.redux.testsupport
+package com.episode6.redux.testsupport.internal
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter

--- a/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/TurbineExt.kt
+++ b/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/TurbineExt.kt
@@ -1,4 +1,4 @@
-package com.episode6.redux.testsupport
+package com.episode6.redux.testsupport.internal
 
 import app.cash.turbine.ReceiveTurbine
 

--- a/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/stoplight/StopLightState.kt
+++ b/test-support/internal/src/commonMain/kotlin/com/episode6/redux/testsupport/internal/stoplight/StopLightState.kt
@@ -1,4 +1,4 @@
-package com.episode6.redux.testsupport.stoplight
+package com.episode6.redux.testsupport.internal.stoplight
 
 import assertk.Assert
 import assertk.all

--- a/test-support/internal/src/commonTest/kotlin/com/episode6/redux/testsupport/internal/TimingControllerTest.kt
+++ b/test-support/internal/src/commonTest/kotlin/com/episode6/redux/testsupport/internal/TimingControllerTest.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalCoroutinesApi::class)
 
-package com.episode6.redux.testsupport
+package com.episode6.redux.testsupport.internal
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo


### PR DESCRIPTION
We want to expose a public test support module to deal with StoreFlow unit tests. This PR starts that process by defining a new `:test-support:internal`  module and moving everything to it except for the stuff we plan to make public.