### PR TITLE
Add utils to test individual side-effects

### DIFF
--- a/test-support/build.gradle.kts
+++ b/test-support/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.coroutines.test)
         implementation(project(":core"))
+        implementation(project(":side-effects"))
       }
     }
     val commonTest by getting {

--- a/test-support/src/commonMain/kotlin/com/episode6/redux/testsupport/SideEffectTest.kt
+++ b/test-support/src/commonMain/kotlin/com/episode6/redux/testsupport/SideEffectTest.kt
@@ -1,0 +1,24 @@
+package com.episode6.redux.testsupport
+
+import com.episode6.redux.Action
+import com.episode6.redux.sideeffects.SideEffect
+import com.episode6.redux.sideeffects.SideEffectContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Utility function for testing an individual [SideEffect]. Returns the [Flow] of [Action] output using the
+ * given [context] as input.
+ */
+public fun <T> SideEffect<T>.testOutput(context: SideEffectTestContext<T>): Flow<Action> = with(context) { act() }
+
+/**
+ * Utility class for testing individual [SideEffect]s.
+ */
+public class SideEffectTestContext<T>(defaultState: T) : SideEffectContext<T> {
+  public val actionsFlow: MutableSharedFlow<Action> = MutableSharedFlow()
+  public var activeState: T = defaultState
+
+  override val actions: Flow<Action> get() = actionsFlow
+  override suspend fun currentState(): T = activeState
+}

--- a/test-support/src/commonTest/kotlin/com/episode6/redux/testsupport/SideEffectTestTest.kt
+++ b/test-support/src/commonTest/kotlin/com/episode6/redux/testsupport/SideEffectTestTest.kt
@@ -1,0 +1,70 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.redux.testsupport
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.episode6.redux.Action
+import com.episode6.redux.sideeffects.SideEffect
+import com.episode6.redux.testsupport.internal.stoplight.SetGreenLightOn
+import com.episode6.redux.testsupport.internal.stoplight.SetRedLightOn
+import com.episode6.redux.testsupport.internal.stoplight.SetYellowLightOn
+import com.episode6.redux.testsupport.internal.stoplight.StopLightState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class SideEffectTestTest {
+
+  val context = SideEffectTestContext(StopLightState())
+
+  @Test fun testSampleSideEffect_noOpWhenLightsOff() = runTest {
+    val output: Flow<Action> = sampleSideEffect().testOutput(context)
+
+    output.test {
+      context.activeState = StopLightState(redLight = false)
+      context.actionsFlow.emit(SetGreenLightOn(true))
+
+      ensureAllEventsConsumed() // no events
+    }
+  }
+
+  @Test fun testSampleSideEffect_turnOffRedLight() = runTest {
+    val output: Flow<Action> = sampleSideEffect().testOutput(context)
+
+    output.test {
+      context.activeState = StopLightState(redLight = true)
+      context.actionsFlow.emit(SetGreenLightOn(true))
+
+      assertThat(awaitItem()).isEqualTo(SetRedLightOn(false))
+      ensureAllEventsConsumed()
+    }
+  }
+
+  @Test fun testSampleSideEffect_turnOffRedAndYellowLight() = runTest {
+    val output: Flow<Action> = sampleSideEffect().testOutput(context)
+
+    output.test {
+      context.activeState = StopLightState(redLight = true, yellowLight = true)
+      context.actionsFlow.emit(SetGreenLightOn(true))
+
+      assertThat(awaitItem()).isEqualTo(SetRedLightOn(false))
+      assertThat(awaitItem()).isEqualTo(SetYellowLightOn(false))
+      ensureAllEventsConsumed()
+    }
+  }
+}
+
+private fun sampleSideEffect() = SideEffect<StopLightState> {
+  actions.filterIsInstance<SetGreenLightOn>().transformLatest {
+    val state = currentState()
+    if (it.on) {
+      if (state.redLight) emit(SetRedLightOn(false))
+      if (state.yellowLight) emit(SetYellowLightOn(false))
+    }
+  }
+}

--- a/test-support/src/commonTest/kotlin/com/episode6/redux/testsupport/SideEffectTestTest.kt
+++ b/test-support/src/commonTest/kotlin/com/episode6/redux/testsupport/SideEffectTestTest.kt
@@ -33,6 +33,17 @@ class SideEffectTestTest {
     }
   }
 
+  @Test fun testSampleSideEffect_noOpWhenActionIsOff() = runTest {
+    val output: Flow<Action> = sampleSideEffect().testOutput(context)
+
+    output.test {
+      context.activeState = StopLightState(redLight = true, yellowLight = true)
+      context.actionsFlow.emit(SetGreenLightOn(false))
+      
+      ensureAllEventsConsumed() // no events
+    }
+  }
+
   @Test fun testSampleSideEffect_turnOffRedLight() = runTest {
     val output: Flow<Action> = sampleSideEffect().testOutput(context)
 


### PR DESCRIPTION
Adds `SideEffectTestContext` and `public fun <T> SideEffect<T>.testOutput(context: SideEffectTestContext<T>): Flow<Action>` for testing side-effects individually.