### PR TITLE
Add some quick tests for StoreManager and runStoreTest

### DIFF
--- a/test-support/src/commonTest/kotlin/com/episode6/redux/testsupport/StoreManagerTest.kt
+++ b/test-support/src/commonTest/kotlin/com/episode6/redux/testsupport/StoreManagerTest.kt
@@ -1,0 +1,35 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.redux.testsupport
+
+import assertk.assertThat
+import com.episode6.redux.testsupport.internal.stoplight.SetGreenLightOn
+import com.episode6.redux.testsupport.internal.stoplight.SetRedLightOn
+import com.episode6.redux.testsupport.internal.stoplight.createStopLightStore
+import com.episode6.redux.testsupport.internal.stoplight.hasLights
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class StoreManagerTest {
+
+  @Test fun testSimpleStore_manager() = runTest {
+    val storeManager = StoreManager { createStopLightStore() }
+    val store = storeManager.store()
+
+    store.dispatch(SetRedLightOn(false))
+    store.dispatch(SetGreenLightOn(true))
+
+    assertThat(store.state).hasLights(green = true)
+
+    storeManager.shutdown()
+  }
+
+  @Test fun testSimpleStore_runStoreTest() = runStoreTest(CoroutineScope::createStopLightStore) { store ->
+    store.dispatch(SetRedLightOn(false))
+    store.dispatch(SetGreenLightOn(true))
+
+    assertThat(store.state).hasLights(green = true)
+  }
+}


### PR DESCRIPTION
This isn't super necessary since we're already using these test utils everywhere, but at least we get an example of direct usage of `StoreManager`