### PR TITLE
Jetpack compose support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("org.jetbrains.kotlin.multiplatform") version(libs.versions.kotlin.core.get()) apply(false)
   id("org.jetbrains.dokka") version(libs.versions.dokka.core.get())
+  id("org.jetbrains.compose") version(libs.versions.compose.core.get()) apply(false)
 }
 
 allprojects {

--- a/buildSrc/src/main/groovy/Config.groovy
+++ b/buildSrc/src/main/groovy/Config.groovy
@@ -18,7 +18,6 @@ class Config {
         "linuxX64",
     ]
     public static String[] apple = [
-        "iosArm32",
         "iosArm64",
         "iosX64",
         "iosSimulatorArm64",

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,0 +1,18 @@
+description = "Jetpack Compose support for Redux StoreFlow"
+
+plugins {
+  id("config-multi-deploy")
+  id("org.jetbrains.compose")
+}
+
+kotlin {
+  sourceSets {
+    val commonMain by getting {
+      dependencies {
+        api(libs.kotlinx.coroutines.core)
+        api(compose.runtime)
+        api(project(":core"))
+      }
+    }
+  }
+}

--- a/compose/src/commonMain/kotlin/com/episode6/redux/compose/StoreComposeExt.kt
+++ b/compose/src/commonMain/kotlin/com/episode6/redux/compose/StoreComposeExt.kt
@@ -1,0 +1,24 @@
+package com.episode6.redux.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import com.episode6.redux.StoreFlow
+import com.episode6.redux.mapStore
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Collects values from this [StoreFlow] and represents its latest value via [State].
+ */
+@Composable public fun <T> StoreFlow<T>.collectAsState(
+  context: CoroutineContext = EmptyCoroutineContext
+): State<T> = collectAsState(initial = initialState, context = context)
+
+/**
+ * Map this [StoreFlow] before collecting values from it.
+ */
+@Composable public fun <IN, OUT> StoreFlow<IN>.collectStoreAsState(
+  context: CoroutineContext = EmptyCoroutineContext,
+  mapper: (IN) -> OUT
+): State<OUT> = mapStore(mapper).collectAsState(context = context)

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -3,6 +3,7 @@ gradle-core = "7.5.1"
 kotlin-core = "1.7.10"
 kotlinx-coroutines = "1.6.4"
 dokka-core = "1.7.10"
+compose-core = "1.2.0-beta01"
 
 # test utils
 assertk-core = "0.25"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ include(
   ":core",
   ":side-effects",
   ":subscriber-aware",
+  ":compose",
 
   ":test-support",
   ":test-support:internal",


### PR DESCRIPTION
 - removed support for iosArm32 which is supposedly old iphone <= 5, this will get restored in the next PR