### PR TITLE
Define an ignore list for certain targets

### DIFF
--- a/buildSrc/src/main/groovy/Config.groovy
+++ b/buildSrc/src/main/groovy/Config.groovy
@@ -43,7 +43,13 @@ class Config {
         "iosArm32": [":compose"]
     ]
 
-    public static String[] filterTargetsFor(String[] targets, String projectPath) {
+    public static String[] filterNativesFor(String projectPath) {
+      return filterTargetsFor(natives, projectPath)
+    }
+    public static String[] filterAllFor(String projectPath) {
+      return filterTargetsFor(all, projectPath)
+    }
+    private static String[] filterTargetsFor(String[] targets, String projectPath) {
        return targets.findAll {
          def ignoreList = ignore[it]
          ignoreList == null || !ignoreList.contains(projectPath)

--- a/buildSrc/src/main/groovy/Config.groovy
+++ b/buildSrc/src/main/groovy/Config.groovy
@@ -49,6 +49,9 @@ class Config {
     public static String[] filterAllFor(String projectPath) {
       return filterTargetsFor(all, projectPath)
     }
+    public static String[] filterHasTestSupportFor(String projectPath) {
+      return filterTargetsFor(all, projectPath) - "mingwX64"
+    }
     private static String[] filterTargetsFor(String[] targets, String projectPath) {
        return targets.findAll {
          def ignoreList = ignore[it]

--- a/buildSrc/src/main/groovy/Config.groovy
+++ b/buildSrc/src/main/groovy/Config.groovy
@@ -43,16 +43,16 @@ class Config {
         "iosArm32": [":compose"]
     ]
 
-    public static String[] filterNativesFor(String projectPath) {
-      return filterTargetsFor(natives, projectPath)
+    public static String[] filterNatives(String projectPath) {
+      return filterTargetsForProjectPath(natives, projectPath)
     }
-    public static String[] filterAllFor(String projectPath) {
-      return filterTargetsFor(all, projectPath)
+    public static String[] filterAll(String projectPath) {
+      return filterTargetsForProjectPath(all, projectPath)
     }
-    public static String[] filterHasTestSupportFor(String projectPath) {
-      return filterTargetsFor(all, projectPath) - "mingwX64"
+    public static String[] filterHasTestSupport(String projectPath) {
+      return filterTargetsForProjectPath(all, projectPath) - "mingwX64"
     }
-    private static String[] filterTargetsFor(String[] targets, String projectPath) {
+    private static String[] filterTargetsForProjectPath(String[] targets, String projectPath) {
        return targets.findAll {
          def ignoreList = ignore[it]
          ignoreList == null || !ignoreList.contains(projectPath)

--- a/buildSrc/src/main/groovy/Config.groovy
+++ b/buildSrc/src/main/groovy/Config.groovy
@@ -18,6 +18,7 @@ class Config {
         "linuxX64",
     ]
     public static String[] apple = [
+        "iosArm32",
         "iosArm64",
         "iosX64",
         "iosSimulatorArm64",
@@ -37,6 +38,17 @@ class Config {
     ]
     public static String[] natives = linux + apple + windows
     public static String[] all = natives + ["jvm", "js"]
+    public static Map<String, String[]> ignore = [
+        "mingwX64": [":test-support:internal"],
+        "iosArm32": [":compose"]
+    ]
+
+    public static String[] filterTargetsFor(String[] targets, String projectPath) {
+       return targets.findAll {
+         def ignoreList = ignore[it]
+         ignoreList == null || !ignoreList.contains(projectPath)
+       }
+    }
   }
 
   class Maven {

--- a/buildSrc/src/main/groovy/Config.groovy
+++ b/buildSrc/src/main/groovy/Config.groovy
@@ -39,8 +39,8 @@ class Config {
     public static String[] natives = linux + apple + windows
     public static String[] all = natives + ["jvm", "js"]
     public static Map<String, String[]> ignore = [
-        "mingwX64": [":test-support:internal"],
-        "iosArm32": [":compose"]
+        "mingwX64": [":test-support:internal"], // assertK doesn't support mingwX64 yet
+        "iosArm32": [":compose"] // compose multiplatform doesn't include support for iosArm32
     ]
 
     public static String[] filterNatives(String projectPath) {

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
@@ -40,7 +40,9 @@ class ConfigMultiPlugin implements Plugin<Project> {
             }
           }
         }
-        for (t in Config.KMPTargets.natives) {
+
+        def natives = Config.KMPTargets.filterTargetsFor(Config.KMPTargets.natives, path)
+        for (t in natives) {
           targets.add(presets.getByName(t).createTarget(t)) {
             compilations.all {
               kotlinOptions {
@@ -57,7 +59,9 @@ class ConfigMultiPlugin implements Plugin<Project> {
               implementation(kotlin("test"))
             }
           }
-          for (sourceSet in Config.KMPTargets.all) {
+
+          def allTargets = Config.KMPTargets.filterTargetsFor(Config.KMPTargets.all, path)
+          for (sourceSet in allTargets) {
             getByName("${sourceSet}Main") {
               dependsOn(commonMain)
             }

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
@@ -42,7 +42,7 @@ class ConfigMultiPlugin implements Plugin<Project> {
         }
 
 
-        for (t in Config.KMPTargets.filterNativesFor(path)) {
+        for (t in Config.KMPTargets.filterNatives(path)) {
           targets.add(presets.getByName(t).createTarget(t)) {
             compilations.all {
               kotlinOptions {
@@ -60,13 +60,13 @@ class ConfigMultiPlugin implements Plugin<Project> {
             }
           }
           
-          for (sourceSet in Config.KMPTargets.filterAllFor(path)) {
+          for (sourceSet in Config.KMPTargets.filterAll(path)) {
             getByName("${sourceSet}Main") {
               dependsOn(commonMain)
             }
           }
 
-          for (sourceSet in Config.KMPTargets.filterHasTestSupportFor(path)) {
+          for (sourceSet in Config.KMPTargets.filterHasTestSupport(path)) {
             getByName("${sourceSet}Test") {
               dependsOn(commonTest)
             }

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
@@ -41,8 +41,8 @@ class ConfigMultiPlugin implements Plugin<Project> {
           }
         }
 
-        def natives = Config.KMPTargets.filterTargetsFor(Config.KMPTargets.natives, path)
-        for (t in natives) {
+
+        for (t in Config.KMPTargets.filterNativesFor(path)) {
           targets.add(presets.getByName(t).createTarget(t)) {
             compilations.all {
               kotlinOptions {
@@ -59,9 +59,8 @@ class ConfigMultiPlugin implements Plugin<Project> {
               implementation(kotlin("test"))
             }
           }
-
-          def allTargets = Config.KMPTargets.filterTargetsFor(Config.KMPTargets.all, path)
-          for (sourceSet in allTargets) {
+          
+          for (sourceSet in Config.KMPTargets.filterAllFor(path)) {
             getByName("${sourceSet}Main") {
               dependsOn(commonMain)
             }

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
@@ -65,6 +65,12 @@ class ConfigMultiPlugin implements Plugin<Project> {
               dependsOn(commonMain)
             }
           }
+
+          for (sourceSet in Config.KMPTargets.filterHasTestSupportFor(path)) {
+            getByName("${sourceSet}Test") {
+              dependsOn(commonTest)
+            }
+          }
         }
       }
     }

--- a/test-support/internal/build.gradle.kts
+++ b/test-support/internal/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
   id("config-multi")
 }
 
-// assertK doesn't support windows builds yet, simply disabling the task results doesn't solve the issue
-rootProject.gradle.startParameter.excludedTaskNames.add(":test-support:internal:compileKotlinMingwX64")
-
 kotlin {
   sourceSets {
     val commonMain by getting {


### PR DESCRIPTION
Slightly less hacky way to skip certain targets depending on the module path. Restores `iosArm32` target for all modules except `:compose`