### PR TITLE
Fix Readme Index paths

### DIFF
--- a/docs/_includes/readme_index.html
+++ b/docs/_includes/readme_index.html
@@ -1,7 +1,7 @@
 <h3 id="readme-index">Readme Index</h3>
 
 <ul>
-  <li><a href="#installation">Installation</a></li>
+  <li><a href="index.html#installation">Installation</a></li>
   <li><a href="STORE_FLOW.html#storeflow-core-api">StoreFlow Core Api</a></li>
   <li><a href="SIDE_EFFECTS.html#sideeffects">SideEffects</a></li>
   <li><a href="SUBSCRIBER_AWARE.html#subscriber-aware-storeflow">Subscriber Aware StoreFlow</a></li>

--- a/docs/_includes/readme_index.html
+++ b/docs/_includes/readme_index.html
@@ -1,10 +1,10 @@
 <h3 id="readme-index">Readme Index</h3>
 
 <ul>
-  <li><a href="/#installation">Installation</a></li>
-  <li><a href="/STORE_FLOW.html#storeflow-core-api">StoreFlow Core Api</a></li>
-  <li><a href="/SIDE_EFFECTS.html#sideeffects">SideEffects</a></li>
-  <li><a href="/SUBSCRIBER_AWARE.html#subscriber-aware-storeflow">Subscriber Aware StoreFlow</a></li>
-  <li><a href="/JETPACK_COMPOSE.html#jetpack-compose-support">Jetpack Compose Support</a></li>
-  <li><a href="/TEST_SUPPORT.html#unit-test-support">Unit Test Support</a></li>
+  <li><a href="#installation">Installation</a></li>
+  <li><a href="STORE_FLOW.html#storeflow-core-api">StoreFlow Core Api</a></li>
+  <li><a href="SIDE_EFFECTS.html#sideeffects">SideEffects</a></li>
+  <li><a href="SUBSCRIBER_AWARE.html#subscriber-aware-storeflow">Subscriber Aware StoreFlow</a></li>
+  <li><a href="JETPACK_COMPOSE.html#jetpack-compose-support">Jetpack Compose Support</a></li>
+  <li><a href="TEST_SUPPORT.html#unit-test-support">Unit Test Support</a></li>
 </ul>


### PR DESCRIPTION
Remove / prefix from urls in the readme index, since our site is deployed as a subfolder in episode6.github.io