### PR TITLE
Readme & kdoc fixes

### DIFF
--- a/compose/src/commonMain/kotlin/com/episode6/redux/compose/StoreComposeExt.kt
+++ b/compose/src/commonMain/kotlin/com/episode6/redux/compose/StoreComposeExt.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 /**
  * Map this [StoreFlow] before collecting values from it.
  */
-@Composable public fun <IN, OUT> StoreFlow<IN>.collectStoreAsState(
+@Composable public fun <IN, OUT> StoreFlow<IN>.collectAsState(
   context: CoroutineContext = EmptyCoroutineContext,
   mapper: (IN) -> OUT
 ): State<OUT> = mapStore(mapper).collectAsState(context = context)

--- a/docs/STORE_FLOW.md
+++ b/docs/STORE_FLOW.md
@@ -105,7 +105,7 @@ fun loggingMiddleware() = Middleware { store, next ->
 
 Since a Middleware is executed with a `CoroutineScope`, it can safely launch async work in response to actions, however it's bad practice to defer execution of the `next` dispatch function.  
 
-Currently, the only Middleware we ship `SideEffectMiddleware`, which you can read more about in the [SideEffect Readme](SIDE_EFFECTS.md#sideeffects). If you're new to redux, this should be the only Middleware you need to worry about (besides simple logging).
+Currently, the only Middleware we ship is `SideEffectMiddleware`, which you can read more about in the [SideEffect Readme](SIDE_EFFECTS.md#sideeffects). If you're new to redux, this should be the only Middleware you need to worry about (besides simple logging).
 
 ### ReduceAction Pattern
 

--- a/docs/STORE_FLOW.md
+++ b/docs/STORE_FLOW.md
@@ -37,7 +37,7 @@ typealias Reducer<State> = State.(Action) -> State
 
 ### Sample StoreFlow
 
-Here we demo a sample StoreFlow that manages the state of a traffic light...
+Before we look at Middleware, lets demo a simple StoreFlow that manages the state of a traffic light...
 
 ```kotlin
 data class TrafficLightState(
@@ -50,7 +50,8 @@ data class SetGreenLight(val value: Boolean) : Action
 data class SetYellowLight(val value: Boolean) : Action
 data class SetRedLight(val value: Boolean) : Action
 
-// See the ReduceAction pattern below for a trick to eliminate this additional verbosity
+// The reducer function will only be called from a single coroutine in a single thread.
+// (see the ReduceAction pattern below for a trick to eliminate this additional verbosity)
 private fun TrafficLightState.reduce(action: Action): TrafficLightState = when (action) {
   is SetGreenLight  -> copy(green = action.value)
   is SetYellowLight -> copy(yellow = action.value)
@@ -109,7 +110,7 @@ Currently, the only Middleware we ship is `SideEffectMiddleware`, which you can 
 
 ### ReduceAction Pattern
 
-A common complaint about the Redux pattern is it adds redundant boilerplate due to the addition of Actions and the Reducer. Once way we can limit this verbosity is with the "ReduceAction" pattern...
+A common complaint about the Redux pattern is that it adds redundant boilerplate due to the addition of Actions and the Reducer. Once way we can limit this verbosity is with the "ReduceAction" pattern...
 ```kotlin
 // Only actions that extend our ReduceAction will make changes to the state. 
 // Because we're using a sealed class, we still have complete control of 

--- a/docs/STORE_FLOW.md
+++ b/docs/STORE_FLOW.md
@@ -81,7 +81,7 @@ fun main() {
 
 ### Middleware
 
-A Middleware is a functional interface that has the opportunity to interfere with the processing of an action. It accepts a dispatch function `next`, which allows the action to continue being processed, and returns its own dispatch function in which `next` should be called.
+A Middleware is a functional interface that has the opportunity to interfere with the processing of an action. It accepts a dispatch function `next`, which allows the action to continue being processed. The middleware then returns its own dispatch function in which `next` should be called.
 
 ```kotlin
 fun interface Middleware<State : Any?> {
@@ -125,7 +125,7 @@ data class SetRedLight(val value: Boolean) : ReduceAction({ copy(red = value) })
 fun trafficLightStore(scope: CoroutineScope) = StoreFlow(
   scope = scope,
   initialState = TrafficLightState(),
-  reducer = { (it as? ReduceAction).reduce?.invoke(this) ?: this },
+  reducer = { (it as? ReduceAction)?.reduce?.invoke(this) ?: this },
 )
 ```
 

--- a/docs/SUBSCRIBER_AWARE.md
+++ b/docs/SUBSCRIBER_AWARE.md
@@ -36,7 +36,7 @@ fun trafficServerListenSideEffect(server: TrafficServer) = SideEffect<TrafficLig
 }
 
 // then we update our creator function to use SubscriberAwareStoreFlow 
-// and apply out new side-effect (which is the only one we'll need)
+// and apply our new SideEffect (which is the only one we'll need)
 fun trafficLightStore(scope: CoroutineScope, server: TrafficServer) = SubscriberAwareStoreFlow(
   scope = scope,
   initialState = TrafficLightState(),

--- a/docs/TEST_SUPPORT.md
+++ b/docs/TEST_SUPPORT.md
@@ -3,7 +3,7 @@
 ### Unit Test Support
 <sup>Module: [`com.episode6.redux:test-support:{{ site.version }}`]({{ site.docsDir }}/test-support/com.episode6.redux.testsupport/index.html)</sup>
 
-Because StoreFlow launches a coroutine on init, unit-testing one with kotlin's new-ish `runTest` method is not entirely straightforward (creating a StoreFlow with a TestScope results in a UncompletedCoroutinesError since StoreFlow will intentionally never complete its Job until its CoroutineScope is explicitly cancelled). 
+Because StoreFlow launches a coroutine on init, unit-testing with kotlin's new-ish `runTest` method is not entirely straightforward (creating a StoreFlow with a TestScope results in a UncompletedCoroutinesError since StoreFlow will intentionally never complete its Job until its CoroutineScope is explicitly cancelled). 
 
 To deal with this, we supply a `StoreManager` in the `:test-support` module. The StoreManager is used to create and shutdown the StoreFlow that is being tested. 
 

--- a/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffect.kt
+++ b/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffect.kt
@@ -3,11 +3,31 @@ package com.episode6.redux.sideeffects
 import com.episode6.redux.Action
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * SideEffects offer a way to include managed async operations in a [StoreFlow].
+ * The primary input is [SideEffectContext.actions], which will receive an emission
+ * for every [Action] dispatched to the Store. The SideEffect returns a new [Flow]
+ * of [Action] which will subsequently be dispatched back into the Store.
+ */
 public fun interface SideEffect<State : Any?> {
   public fun SideEffectContext<State>.act(): Flow<Action>
 }
 
+/**
+ * The receiver passed to a [SideEffect]. The primary input is [actions], however
+ * we the [currentState] can also be captured at any time inside the SideEffect.
+ */
 public interface SideEffectContext<State: Any?> {
+
+  /**
+   * A [Flow] of all the actions dispatched to the [StoreFlow]. A well-behaved
+   * SideEffect will usually filterIsInstance<SpecificAction>() then transformLatest
+   * to emit new actions back into the [StoreFlow]
+   */
   public val actions: Flow<Action>
+
+  /**
+   * Returns the current state of the [StoreFlow] at function call-time.
+   */
   public suspend fun currentState(): State
 }

--- a/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffectMiddleware.kt
+++ b/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffectMiddleware.kt
@@ -5,10 +5,19 @@ import com.episode6.redux.Middleware
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
+/**
+ * Returns a [Middleware] that passes actions to the supplied [sideEffects], then dispatches
+ * their returned [Action]s back into the [StoreFlow]
+ */
 @Suppress("FunctionName")
 public fun <State : Any?> SideEffectMiddleware(vararg sideEffects: SideEffect<State>): Middleware<State> =
   SideEffectMiddleware(sideEffects.toList())
 
+
+/**
+ * Returns a [Middleware] that passes actions to the supplied [sideEffects], then dispatches
+ * their returned [Action]s back into the [StoreFlow]
+ */
 @Suppress("FunctionName")
 public fun <State : Any?> SideEffectMiddleware(sideEffects: Collection<SideEffect<State>>): Middleware<State> =
   Middleware { store, next ->

--- a/store-flow/src/commonMain/kotlin/com/episode6/redux/api.kt
+++ b/store-flow/src/commonMain/kotlin/com/episode6/redux/api.kt
@@ -23,7 +23,7 @@ public interface Action
 public typealias Reducer<State> = State.(Action) -> State
 
 /**
- * Gets the chance to interfere with a [StoreFlow]'s dispatch of actions
+ * Gets the chance to interfere with a [StoreFlow]'s dispatch/processing of actions
  */
 public fun interface Middleware<State : Any?> {
   public fun CoroutineScope.interfere(store: StoreFlow<State>, next: Dispatch): Dispatch

--- a/store-flow/src/commonMain/kotlin/com/episode6/redux/ext.kt
+++ b/store-flow/src/commonMain/kotlin/com/episode6/redux/ext.kt
@@ -4,6 +4,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
+/**
+ * Maps a [StoreFlow] that emits a state of type [T] to one that
+ * emits a state of type [R], by applying the given [mapper] to
+ * its emissions.
+ *
+ * The only difference will be the state that is emitted. Any actions
+ * dispatched to the resulting [StoreFlow] will be passed directly back
+ * to the receiver.
+ */
 public fun <T, R> StoreFlow<T>.mapStore(mapper: (T) -> R): StoreFlow<R> {
   val newFlow = map { mapper(it) }.distinctUntilChanged()
   return object : StoreFlow<R>, Flow<R> by newFlow {


### PR DESCRIPTION
piggyback: rename one of the `collectAsState` methods in the :compose module, as it had been missed and was still names `collectStoreAsState()`