### PR TITLE
[AGENT] Add release-branch-skill

### DIFF
--- a/.agents/release-branch-skill/README.md
+++ b/.agents/release-branch-skill/README.md
@@ -1,0 +1,10 @@
+# Release Branch Skill
+
+This directory contains the skill definition for cutting new release branches for the Redux StoreFlow project.
+
+## Contents
+- `skill.json`: Metadata about the skill.
+- `SKILL.md`: Detailed instructions and steps for the agent to follow.
+
+## Usage
+When tasked with cutting a new release, an agent should follow the steps outlined in `SKILL.md` to ensure consistency with the project's release process.

--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -28,7 +28,6 @@ Create two separate Pull Requests to update versions.
 - **Changes:**
     - Update `version` in `build.gradle.kts` (remove `-SNAPSHOT` if present).
     - Update `docs/CHANGELOG.md` with release date and final version.
-    - Run `./gradlew syncDocs` and include any resulting changes in the commit.
 
 ## Verification
 - After these steps, the project is ready for the "Harden Release Branch" phase, which requires manual verification and cherry-picking of bug fixes.

--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -1,0 +1,33 @@
+# Cut Release Branch Skill
+
+This skill automates and describes the process of cutting a new release branch and preparing the version bumps, as defined in `RELEASE_CHECKLIST.md`.
+
+## Steps to Execute
+
+### 1. Pre-check
+- Ensure the `main` branch is passing all CI checks (is "green").
+
+### 2. Cut new Release Branch
+- Checkout the `main` branch and pull the latest changes.
+- Create a new branch: `git checkout -b release/v<VERSION>`
+- Push the empty branch and set it to be tracked: `git push -u origin release/v<VERSION>`
+
+### 3. Version Bump PRs
+Create two separate Pull Requests to update versions.
+
+#### PR 1: Snapshot Version on `main`
+- **Target Branch:** `main`
+- **PR Title:** `[VERSION] Snapshot v<NEXT_VERSION>-SNAPSHOT`
+- **Changes:**
+    - Update `version` in `build.gradle.kts`.
+    - Update `docs/CHANGELOG.md` if necessary.
+
+#### PR 2: Release Version on Release Branch
+- **Target Branch:** `release/v<VERSION>`
+- **PR Title:** `[VERSION] Release v<VERSION>`
+- **Changes:**
+    - Update `version` in `build.gradle.kts` (remove `-SNAPSHOT` if present).
+    - Update `docs/CHANGELOG.md` with release date and final version.
+
+## Verification
+- After these steps, the project is ready for the "Harden Release Branch" phase, which requires manual verification and cherry-picking of bug fixes.

--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -28,6 +28,7 @@ Create two separate Pull Requests to update versions.
 - **Changes:**
     - Update `version` in `build.gradle.kts` (remove `-SNAPSHOT` if present).
     - Update `docs/CHANGELOG.md` with release date and final version.
+    - Run `./gradlew syncDocs` and include any resulting changes in the commit.
 
 ## Verification
 - After these steps, the project is ready for the "Harden Release Branch" phase, which requires manual verification and cherry-picking of bug fixes.

--- a/.agents/release-branch-skill/skill.json
+++ b/.agents/release-branch-skill/skill.json
@@ -1,0 +1,15 @@
+{
+  "id": "release-branch-skill",
+  "name": "Cut Release Branch",
+  "version": "1.0.0",
+  "description": "Process for cutting a new release branch and performing version bumps.",
+  "author": "ghackett",
+  "entry": "SKILL.md",
+  "created_at": "2026-06-14T17:00:00-04:00",
+  "tags": ["release", "git", "versioning"],
+  "required_actions": [
+    "Check CI status on main",
+    "Create release branch",
+    "Create version bump PRs for main and release branches"
+  ]
+}

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -16,7 +16,6 @@
     - Update version in files:
         - `build.gradle.kts`
         - `docs/CHANGELOG.md`
-    - Run `./gradlew syncDocs` and include changes in the commit.
 
 ### Harden Release Branch
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -16,6 +16,7 @@
     - Update version in files:
         - `build.gradle.kts`
         - `docs/CHANGELOG.md`
+    - Run `./gradlew syncDocs` and include changes in the commit.
 
 ### Harden Release Branch
 


### PR DESCRIPTION
Automates and describes the process of cutting a new release branch and preparing version bumps, as defined in RELEASE_CHECKLIST.md.