### PR TITLE
CI: Enable enhanced Gradle caching

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
-      with:
-        cache-provider: basic
     - name: Assemble Project
       run: ./gradlew assemble -Pfilter=${{ matrix.filter }}
     - name: Check Project

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-provider: basic
       - name: Clean Project
         run: ./gradlew clean
       - name: Generate Docs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0-SNAPSHOT - Unreleased
 
-- CI: Use gradle/actions/setup-gradle@v6 and actions/setup-java@v5 (Azul Zulu); enable basic Gradle caching in GitHub workflows
+- CI: Use gradle/actions/setup-gradle@v6 and actions/setup-java@v5 (Azul Zulu); enable enhanced Gradle caching in GitHub workflows
 - Added GitHub Actions workflow and local script (`scripts/verify-docs-updated.sh`) for verifying documentation updates on pull requests.
 - Upgraded Kotlin to 2.4.0
 - Added Compose Compiler plugin to the build for Kotlin 2.x support.


### PR DESCRIPTION
Updates GitHub workflows to use enhanced caching provided by gradle/actions/setup-gradle@v6.