### PR TITLE
feat(release): add ship-release local skill

### DIFF
--- a/.agents/ship-release-skill/README.md
+++ b/.agents/ship-release-skill/README.md
@@ -1,0 +1,10 @@
+# Ship Release Branch Skill
+
+This directory contains the skill definition for shipping a release branch by publishing a GitHub release pointing to the tip of the release branch.
+
+## Contents
+- `skill.json`: Metadata about the skill.
+- `SKILL.md`: Detailed instructions and steps for the agent to follow.
+
+## Usage
+When tasked with shipping a release branch, the agent should follow the steps outlined in `SKILL.md` to ensure that the version name is correctly parsed from the repository, the release notes are extracted from the changelog, and the GitHub release is published using the `gh` CLI.

--- a/.agents/ship-release-skill/SKILL.md
+++ b/.agents/ship-release-skill/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: ship-release-skill
+description: >-
+  Ship a release branch by publishing a GitHub release using the gh CLI. Parses
+  version from build.gradle.kts and gets release notes from docs/CHANGELOG.md.
+---
+
+# Ship Release Branch Skill
+
+## Overview
+This skill guides the agent in shipping a release branch by creating and publishing a GitHub release pointing to the tip of the release branch. It ensures consistency by:
+1. Resolving the release version directly from `build.gradle.kts` on the target release branch (never assuming the branch name matches the version name, as hotfixes are appended to existing release branches).
+2. Extracting release notes from the corresponding section in `docs/CHANGELOG.md`.
+3. Publishing the GitHub release using the `gh` CLI with matching tag name and release name (format: `v<VERSION>`).
+
+## Dependencies
+- `release-branch-skill`: Typically run after a release branch is cut and hardened.
+
+## Quick Start
+To perform a dry-run and verify release notes/version before shipping:
+```bash
+./scripts/ship-release.py --dry-run --output /tmp/release-dry-run.json
+```
+
+To ship the current release branch:
+```bash
+./scripts/ship-release.py --output /tmp/release-result.json
+```
+
+## Utility Scripts
+The skill uses the `./scripts/ship-release.py` script.
+
+### Arguments
+- `--branch <branch>`: Target branch/ref to point the release to (defaults to current branch).
+- `--dry-run`: Prints release details and the `gh` command without executing them.
+- `--output <file_path>`: (Required) Path to write a JSON report of the release results.
+
+### Example JSON output (`/tmp/release-result.json`):
+```json
+{
+  "success": true,
+  "dry_run": false,
+  "tag": "v1.1.0",
+  "title": "v1.1.0",
+  "branch": "release/v1.1.0",
+  "url": "https://github.com/episode6/redux-store-flow/releases/tag/v1.1.0",
+  "notes": "- CI: Use gradle/actions/setup-gradle@v6...\n- Upgraded Kotlin to 2.4.0..."
+}
+```
+
+## Common Mistakes
+1. **Shipping a Snapshot**: Trying to ship when the version in `build.gradle.kts` still contains `-SNAPSHOT`. The script will detect this and fail.
+2. **Missing Changelog Section**: Forgetting to update `docs/CHANGELOG.md` with the release version and date. The script will fail if the section matching `v<VERSION>` cannot be found.
+3. **Mismatched release notes**: Assuming the release notes can be typed manually. Always extract them directly from `docs/CHANGELOG.md` using the script to avoid discrepancies.

--- a/.agents/ship-release-skill/skill.json
+++ b/.agents/ship-release-skill/skill.json
@@ -1,0 +1,15 @@
+{
+  "id": "ship-release-skill",
+  "name": "Ship Release Branch",
+  "version": "1.0.0",
+  "description": "Process for shipping a release branch by publishing a GitHub release pointing to the tip of the release branch with version and notes extracted from the codebase.",
+  "author": "ghackett",
+  "entry": "SKILL.md",
+  "created_at": "2026-06-15T16:47:00-04:00",
+  "tags": ["release", "git", "github", "gh-cli"],
+  "required_actions": [
+    "Parse version from build.gradle.kts on the release branch",
+    "Extract release notes from docs/CHANGELOG.md",
+    "Publish GitHub release using gh CLI pointing to the tip of the release branch"
+  ]
+}

--- a/scripts/ship-release.py
+++ b/scripts/ship-release.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+def get_current_branch():
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting current git branch: {e.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+
+def get_version():
+    gradle_file = "build.gradle.kts"
+    if not os.path.exists(gradle_file):
+        print(f"Error: {gradle_file} not found in the current directory.", file=sys.stderr)
+        sys.exit(1)
+        
+    with open(gradle_file, "r") as f:
+        content = f.read()
+        
+    # Search for version = "..."
+    match = re.search(r'version\s*=\s*"([^"]+)"', content)
+    if not match:
+        print("Error: Could not find version pattern in build.gradle.kts", file=sys.stderr)
+        sys.exit(1)
+        
+    version = match.group(1)
+    if version.endswith("-SNAPSHOT"):
+        print(f"Error: Version '{version}' ends with -SNAPSHOT. Release version must be resolved/bumped first.", file=sys.stderr)
+        sys.exit(1)
+        
+    return version
+
+def get_changelog_notes(version):
+    changelog_file = "docs/CHANGELOG.md"
+    if not os.path.exists(changelog_file):
+        print(f"Error: {changelog_file} not found.", file=sys.stderr)
+        sys.exit(1)
+        
+    with open(changelog_file, "r") as f:
+        lines = f.readlines()
+        
+    notes = []
+    found_section = False
+    
+    # We look for a line starting with '## v<version>'
+    header_pattern = re.compile(rf"^##\s+v{re.escape(version)}(\s+|$|-)")
+    any_header_pattern = re.compile(r"^##\s+v\d+")
+    
+    for line in lines:
+        if found_section:
+            if any_header_pattern.match(line):
+                break
+            notes.append(line)
+        elif header_pattern.match(line):
+            found_section = True
+            
+    if not found_section:
+        print(f"Error: Could not find changelog section for v{version} in docs/CHANGELOG.md", file=sys.stderr)
+        sys.exit(1)
+        
+    content = "".join(notes).strip()
+    if not content:
+        print(f"Warning: Changelog notes for v{version} are empty.", file=sys.stderr)
+        
+    return content
+
+def run_gh_release(version, notes, target_branch, dry_run=False):
+    tag_name = f"v{version}"
+    release_name = f"v{version}"
+    
+    # Create temp file for release notes
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.md', delete=False) as temp_notes:
+        temp_notes.write(notes)
+        temp_notes_path = temp_notes.name
+        
+    try:
+        cmd = [
+            "gh", "release", "create", tag_name,
+            "--title", release_name,
+            "--notes-file", temp_notes_path,
+            "--target", target_branch
+        ]
+        
+        if dry_run:
+            print("[DRY-RUN] Would execute command:")
+            print(" ".join(cmd))
+            print("\n[DRY-RUN] Release Notes:")
+            print("-" * 40)
+            print(notes)
+            print("-" * 40)
+            return {
+                "success": True,
+                "dry_run": True,
+                "tag": tag_name,
+                "title": release_name,
+                "branch": target_branch,
+                "command": " ".join(cmd),
+                "notes": notes
+            }
+        else:
+            print(f"Running: {' '.join(cmd)}")
+            result = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True
+            )
+            release_url = result.stdout.strip()
+            print(f"Success! Created release: {release_url}")
+            return {
+                "success": True,
+                "dry_run": False,
+                "tag": tag_name,
+                "title": release_name,
+                "branch": target_branch,
+                "url": release_url,
+                "notes": notes
+            }
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing gh release: {e.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        if os.path.exists(temp_notes_path):
+            os.remove(temp_notes_path)
+
+def main():
+    parser = argparse.ArgumentParser(description="Ship a release branch by publishing it on GitHub.")
+    parser.add_argument("--branch", help="Target branch/ref to point the release to (defaults to current branch)")
+    parser.add_argument("--dry-run", action="store_true", help="Print details of the release without publishing")
+    parser.add_argument("--output", help="Optional path to write a JSON report of the release results")
+    
+    args = parser.parse_args()
+    
+    # Require --output argument to comply with Rule 3 (CLI Script Pattern)
+    if not args.output:
+        print("Error: --output <file_path> is required to capture the execution results.", file=sys.stderr)
+        sys.exit(1)
+        
+    branch = args.branch if args.branch else get_current_branch()
+    version = get_version()
+    notes = get_changelog_notes(version)
+    
+    result = run_gh_release(version, notes, branch, dry_run=args.dry_run)
+    
+    # Write JSON output report
+    with open(args.output, "w") as f:
+        json.dump(result, f, indent=2)
+        
+    print(f"Execution results written to: {args.output}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-docs-updated.sh
+++ b/scripts/verify-docs-updated.sh
@@ -20,7 +20,7 @@ git fetch origin --no-tags --prune || true
 CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
 
 if [ -z "$CHANGED_FILES" ]; then
-  echo "No changes detected between $BASE_REF and HEAD."
+  echo "No code changes detected."
   exit 0
 fi
 
@@ -55,5 +55,9 @@ if [ "$CODE_CHANGED" = true ] && [ "$DOCS_UPDATED" = false ]; then
   exit 1
 fi
 
-echo "Docs updated or no code changes detected."
+if [ "$DOCS_UPDATED" = true ]; then
+  echo "Docs updated."
+else
+  echo "No code changes detected."
+fi
 exit 0

--- a/scripts/verify-docs-updated.sh
+++ b/scripts/verify-docs-updated.sh
@@ -6,11 +6,18 @@ set -euo pipefail
 
 BASE_REF=${1:-origin/main}
 
+# If the specified ref doesn't exist locally, try resolving it as origin/<ref>
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  if git rev-parse --verify "origin/$BASE_REF" >/dev/null 2>&1; then
+    BASE_REF="origin/$BASE_REF"
+  fi
+fi
+
 # Ensure we have the base for comparison
 git fetch origin --no-tags --prune || true
 
 # Compute changed files between base and HEAD
-CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD || true)
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "No changes detected between $BASE_REF and HEAD."


### PR DESCRIPTION
This PR adds the ship-release local agent skill and the associated ship-release.py helper script to automate publishing release tags/releases via gh CLI.

Additionally, this PR includes a fix for the docs verification script (scripts/verify-docs-updated.sh) to correctly resolve the base branch reference against origin in GitHub Actions environments.