### PR TITLE
Update publish-artifacts workflow for Sonatype Central Portal

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
             ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }}
             if [ "${{ github.ref_type }}" == "tag" ]; then
               SONATYPE_TOKEN=$(echo -n "${ORG_GRADLE_PROJECT_nexusUsername}:${ORG_GRADLE_PROJECT_nexusPassword}" | base64 | tr -d '\n')
-              curl -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.episode6?publishingType=AUTOMATIC" \
+              curl -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.episode6" \
                    -H "Authorization: Bearer ${SONATYPE_TOKEN}"
             fi
           else

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -42,6 +42,11 @@ jobs:
         run: |
           if [ "${{ matrix.filter }}" == "macos" ]; then
             ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }}
+            if [ "${{ github.ref_type }}" == "tag" ]; then
+              SONATYPE_TOKEN=$(echo -n "${ORG_GRADLE_PROJECT_nexusUsername}:${ORG_GRADLE_PROJECT_nexusPassword}" | base64 | tr -d '\n')
+              curl -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.episode6?publishingType=AUTOMATIC" \
+                   -H "Authorization: Bearer ${SONATYPE_TOKEN}"
+            fi
           else
             ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }} -Pkotlin.mpp.enableMetadataPublishing=false
           fi


### PR DESCRIPTION
This PR updates the publish-artifacts workflow to include a POST request to the Sonatype Central Portal API after publishing from the macos runner. This is required for the new Sonatype Central publishing flow.