### PR TITLE
Improve release skill: enforce non-SNAPSHOT, pull from origin, and emphasize changelog

### DIFF
--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -20,14 +20,14 @@ Create two separate Pull Requests to update versions.
 - **PR Title:** `[VERSION] Snapshot v<NEXT_VERSION>-SNAPSHOT`
 - **Changes:**
     - Update `version` in `build.gradle.kts`.
-    - Update `docs/CHANGELOG.md` if necessary.
+    - **(VITAL)** Update `docs/CHANGELOG.md` to include a new "Unreleased" section for the next version.
 
 #### PR 2: Release Version on Release Branch
 - **Target Branch:** `release/v<VERSION>`
 - **PR Title:** `[VERSION] Release v<VERSION>`
 - **Changes:**
     - Update `version` in `build.gradle.kts` (remove `-SNAPSHOT` if present).
-    - Update `docs/CHANGELOG.md` with release date and final version.
+    - **(VITAL)** Update `docs/CHANGELOG.md` with the release date and the final version. Ensure all changes since the last release are documented.
 
 ## Verification
 - After these steps, the project is ready for the "Harden Release Branch" phase, which requires manual verification and cherry-picking of bug fixes.

--- a/.agents/release-branch-skill/skill.json
+++ b/.agents/release-branch-skill/skill.json
@@ -10,6 +10,7 @@
   "required_actions": [
     "Check CI status on main",
     "Create release branch",
-    "Create version bump PRs for main and release branches"
+    "Create version bump PRs for main and release branches",
+    "Update docs/CHANGELOG.md in both PRs (VITAL)"
   ]
 }

--- a/.agents/ship-release-skill/SKILL.md
+++ b/.agents/ship-release-skill/SKILL.md
@@ -18,6 +18,7 @@ This skill guides the agent in shipping a release branch by creating and publish
 
 ## Prerequisites
 - Ensure the local release branch is up-to-date by pulling from `origin` before starting the release process.
+- **Verify Version**: The version in `build.gradle.kts` must NOT end with `-SNAPSHOT`. If it does, the release process must be aborted until the version is properly bumped.
 
 ## Quick Start
 To perform a dry-run and verify release notes/version before shipping:

--- a/.agents/ship-release-skill/SKILL.md
+++ b/.agents/ship-release-skill/SKILL.md
@@ -16,6 +16,9 @@ This skill guides the agent in shipping a release branch by creating and publish
 ## Dependencies
 - `release-branch-skill`: Typically run after a release branch is cut and hardened.
 
+## Prerequisites
+- Ensure the local release branch is up-to-date by pulling from `origin` before starting the release process.
+
 ## Quick Start
 To perform a dry-run and verify release notes/version before shipping:
 ```bash
@@ -52,3 +55,4 @@ The skill uses the `./scripts/ship-release.py` script.
 1. **Shipping a Snapshot**: Trying to ship when the version in `build.gradle.kts` still contains `-SNAPSHOT`. The script will detect this and fail.
 2. **Missing Changelog Section**: Forgetting to update `docs/CHANGELOG.md` with the release version and date. The script will fail if the section matching `v<VERSION>` cannot be found.
 3. **Mismatched release notes**: Assuming the release notes can be typed manually. Always extract them directly from `docs/CHANGELOG.md` using the script to avoid discrepancies.
+4. **Stale Local Branch**: Forgetting to pull the latest changes from `origin` before shipping, which can lead to releasing an outdated version of the code.

--- a/.agents/ship-release-skill/skill.json
+++ b/.agents/ship-release-skill/skill.json
@@ -9,6 +9,7 @@
   "tags": ["release", "git", "github", "gh-cli"],
   "required_actions": [
     "Pull latest changes from origin to ensure local branch is up-to-date",
+    "Verify version in build.gradle.kts does not end with -SNAPSHOT (abort if it does)",
     "Parse version from build.gradle.kts on the release branch",
     "Extract release notes from docs/CHANGELOG.md",
     "Publish GitHub release using gh CLI pointing to the tip of the release branch"

--- a/.agents/ship-release-skill/skill.json
+++ b/.agents/ship-release-skill/skill.json
@@ -8,6 +8,7 @@
   "created_at": "2026-06-15T16:47:00-04:00",
   "tags": ["release", "git", "github", "gh-cli"],
   "required_actions": [
+    "Pull latest changes from origin to ensure local branch is up-to-date",
     "Parse version from build.gradle.kts on the release branch",
     "Extract release notes from docs/CHANGELOG.md",
     "Publish GitHub release using gh CLI pointing to the tip of the release branch"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -13,9 +13,9 @@
 - Create 2 PRs to bump version
     - `[VERSION] Snapshot v<version>` points at `main`
     - `[VERSION] Release v<version>` points at new release branch
-    - Update version in files:
+    - Update version in files (VITAL):
         - `build.gradle.kts`
-        - `docs/CHANGELOG.md`
+        - `docs/CHANGELOG.md` (Update with release date and/or new unreleased section)
 
 ### Harden Release Branch
 


### PR DESCRIPTION
Updates the `ship-release` skill and the release checklist to improve reliability and ensure consistency.

Key changes:
- **Pull from origin**: Added a prerequisite to pull the latest changes from `origin` before shipping to prevent releasing stale code.
- **Enforce non-SNAPSHOT**: Added a check to abort the release process if the version in `build.gradle.kts` still ends with `-SNAPSHOT`.
- **Vital changelog updates**: Emphasized that updating `docs/CHANGELOG.md` is a critical part of the version bump process.