### PR TITLE
Refactor publication workflows for releases and snapshots

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           mkdir -p ~/m2-archive
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            powershell -Command "Compress-Archive -Path \$env:USERPROFILE\\.m2\\repository\\com\\episode6\\redux -DestinationPath \$env:USERPROFILE\\m2-archive\\m2-repository.zip"
+            cd ~/.m2/repository
+            powershell -Command "Compress-Archive -Path com/episode6/redux -DestinationPath \$env:USERPROFILE\\m2-archive\\m2-repository.zip"
           else
             cd ~/.m2/repository
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -90,46 +91,3 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
-      - name: Publish to Sonatype Central
-        run: |
-          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
-          curl --request POST \
-            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
-            --form bundle=@sonatype-bundle.zip \
-            'https://central.sonatype.com/api/v1/publisher/upload'
-
-  docs-and-deploy:
-    needs: aggregate-and-publish
-    runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 23
-        uses: actions/setup-java@v5
-        with:
-          java-version: '23'
-          distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Clean Project
-        run: ./gradlew clean
-      - name: Generate Docs
-        run: ./gradlew dokkaGenerateHtml
-      - name: Sync Docs
-        run: ./gradlew syncDocs
-      - name: Deploy root docs to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
-      - name: Deploy dokka to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/dokka/html
-          TARGET_FOLDER: /docs/${{ github.ref_name }}/
-          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
           mkdir -p ~/m2-archive
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
             cd ~/.m2/repository
-            powershell -Command "Compress-Archive -Path com/episode6/redux -DestinationPath \$env:USERPROFILE\\m2-archive\\m2-repository.zip"
+            powershell -Command "Compress-Archive -Path com -DestinationPath \$env:USERPROFILE\\m2-archive\\m2-repository.zip"
           else
             cd ~/.m2/repository
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,5 @@
 name: Publish Release
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
@@ -93,3 +92,46 @@ jobs:
           name: sonatype-bundle
           path: sonatype-bundle.zip
           compression-level: 0
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Sync Docs
+        run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,5 @@
 name: Publish Release
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
@@ -86,3 +85,46 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Sync Docs
+        run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -89,46 +90,3 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
-      - name: Publish to Sonatype Central
-        run: |
-          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
-          curl --request POST \
-            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
-            --form bundle=@sonatype-bundle.zip \
-            'https://central.sonatype.com/api/v1/publisher/upload'
-
-  docs-and-deploy:
-    needs: aggregate-and-publish
-    runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 23
-        uses: actions/setup-java@v5
-        with:
-          java-version: '23'
-          distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Clean Project
-        run: ./gradlew clean
-      - name: Generate Docs
-        run: ./gradlew dokkaGenerateHtml
-      - name: Sync Docs
-        run: ./gradlew syncDocs
-      - name: Deploy root docs to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
-      - name: Deploy dokka to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/dokka/html
-          TARGET_FOLDER: /docs/${{ github.ref_name }}/
-          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,11 +52,11 @@ jobs:
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
           fi
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: m2-${{ matrix.filter }}
           path: ~/m2-archive/m2-repository.zip
-          compression-level: 0
+          archive: false
 
   aggregate-and-publish:
     needs: build-shards
@@ -64,7 +64,7 @@ jobs:
     if: github.repository == 'episode6/redux-store-flow'
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: m2-zips
       - name: Merge Artifacts
@@ -87,11 +87,11 @@ jobs:
           cd bundle
           zip -r ../sonatype-bundle.zip .
       - name: Upload Bundle to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: sonatype-bundle
+          name: sonatype-bundle.zip
           path: sonatype-bundle.zip
-          compression-level: 0
+          archive: false
       - name: Publish to Sonatype Central
         run: |
           SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -92,46 +93,3 @@ jobs:
           name: sonatype-bundle
           path: sonatype-bundle.zip
           compression-level: 0
-      - name: Publish to Sonatype Central
-        run: |
-          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
-          curl --request POST \
-            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
-            --form bundle=@sonatype-bundle.zip \
-            'https://central.sonatype.com/api/v1/publisher/upload'
-
-  docs-and-deploy:
-    needs: aggregate-and-publish
-    runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 23
-        uses: actions/setup-java@v5
-        with:
-          java-version: '23'
-          distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Clean Project
-        run: ./gradlew clean
-      - name: Generate Docs
-        run: ./gradlew dokkaGenerateHtml
-      - name: Sync Docs
-        run: ./gradlew syncDocs
-      - name: Deploy root docs to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
-      - name: Deploy dokka to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/dokka/html
-          TARGET_FOLDER: /docs/${{ github.ref_name }}/
-          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           mkdir -p ~/m2-archive
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            powershell -Command "Compress-Archive -Path $HOME\.m2\repository\com\episode6\redux -DestinationPath $HOME\m2-archive\m2-repository.zip"
+            powershell -Command "Compress-Archive -Path \$env:USERPROFILE\\.m2\\repository\\com\\episode6\\redux -DestinationPath \$env:USERPROFILE\\m2-archive\\m2-repository.zip"
           else
             cd ~/.m2/repository
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,130 @@
+name: Publish Release
+on:
+  push:
+    tags:
+      - 'v*'
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+jobs:
+  build-shards:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            filter: linuxX64
+          - os: windows-latest
+            filter: windowsX64
+          - os: macos-latest
+            filter: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Assert Architecture
+        shell: bash
+        run: bash scripts/assert-architecture.sh "${{ matrix.os }}"
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Publish to Maven Local
+        shell: bash
+        run: ./gradlew publishToMavenLocal -Pfilter=${{ matrix.filter }}
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASS }}
+          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
+      - name: Zip Maven Local
+        shell: bash
+        run: |
+          mkdir -p ~/m2-archive
+          cd ~/.m2/repository
+          zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: m2-${{ matrix.filter }}
+          path: ~/m2-archive/m2-repository.zip
+
+  aggregate-and-publish:
+    needs: build-shards
+    runs-on: ubuntu-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: m2-zips
+      - name: Merge Artifacts
+        run: |
+          mkdir -p bundle
+          find m2-zips -name "*.zip" -exec unzip -o {} -d bundle \;
+      - name: Generate Checksums
+        run: |
+          cd bundle
+          find . -type f \( -name "*.jar" -o -name "*.pom" -o -name "*.module" -o -name "*.asc" \) | while read -r file; do
+            if [ ! -f "$file.md5" ]; then
+              md5sum "$file" | cut -d ' ' -f 1 > "$file.md5"
+            fi
+            if [ ! -f "$file.sha1" ]; then
+              sha1sum "$file" | cut -d ' ' -f 1 > "$file.sha1"
+            fi
+          done
+      - name: Create Sonatype Bundle
+        run: |
+          cd bundle
+          zip -r ../sonatype-bundle.zip .
+      - name: Upload Bundle to GitHub
+        uses: actions/upload-artifact@v4
+        with:
+          name: sonatype-bundle
+          path: sonatype-bundle.zip
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Sync Docs
+        run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -85,46 +86,3 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
-      - name: Publish to Sonatype Central
-        run: |
-          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
-          curl --request POST \
-            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
-            --form bundle=@sonatype-bundle.zip \
-            'https://central.sonatype.com/api/v1/publisher/upload'
-
-  docs-and-deploy:
-    needs: aggregate-and-publish
-    runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 23
-        uses: actions/setup-java@v5
-        with:
-          java-version: '23'
-          distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Clean Project
-        run: ./gradlew clean
-      - name: Generate Docs
-        run: ./gradlew dokkaGenerateHtml
-      - name: Sync Docs
-        run: ./gradlew syncDocs
-      - name: Deploy root docs to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
-      - name: Deploy dokka to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/dokka/html
-          TARGET_FOLDER: /docs/${{ github.ref_name }}/
-          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,5 @@
 name: Publish Release
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
@@ -93,3 +92,46 @@ jobs:
           name: sonatype-bundle.zip
           path: sonatype-bundle.zip
           archive: false
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Sync Docs
+        run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,11 +52,11 @@ jobs:
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
           fi
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: m2-${{ matrix.filter }}
           path: ~/m2-archive/m2-repository.zip
-          archive: false
+          compression-level: 0
 
   aggregate-and-publish:
     needs: build-shards
@@ -64,7 +64,7 @@ jobs:
     if: github.repository == 'episode6/redux-store-flow'
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           path: m2-zips
       - name: Merge Artifacts
@@ -87,11 +87,11 @@ jobs:
           cd bundle
           zip -r ../sonatype-bundle.zip .
       - name: Upload Bundle to GitHub
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
-          name: sonatype-bundle.zip
+          name: sonatype-bundle
           path: sonatype-bundle.zip
-          archive: false
+          compression-level: 0
       - name: Publish to Sonatype Central
         run: |
           SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -92,46 +93,3 @@ jobs:
           name: sonatype-bundle.zip
           path: sonatype-bundle.zip
           archive: false
-      - name: Publish to Sonatype Central
-        run: |
-          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
-          curl --request POST \
-            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
-            --form bundle=@sonatype-bundle.zip \
-            'https://central.sonatype.com/api/v1/publisher/upload'
-
-  docs-and-deploy:
-    needs: aggregate-and-publish
-    runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 23
-        uses: actions/setup-java@v5
-        with:
-          java-version: '23'
-          distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Clean Project
-        run: ./gradlew clean
-      - name: Generate Docs
-        run: ./gradlew dokkaGenerateHtml
-      - name: Sync Docs
-        run: ./gradlew syncDocs
-      - name: Deploy root docs to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
-      - name: Deploy dokka to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/dokka/html
-          TARGET_FOLDER: /docs/${{ github.ref_name }}/
-          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           name: m2-${{ matrix.filter }}
           path: ~/m2-archive/m2-repository.zip
+          compression-level: 0
 
   aggregate-and-publish:
     needs: build-shards
@@ -90,6 +91,7 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
+          compression-level: 0
       - name: Publish to Sonatype Central
         run: |
           SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,5 @@
 name: Publish Release
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
@@ -90,3 +89,46 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Sync Docs
+        run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -91,7 +91,7 @@ jobs:
           curl --request POST \
             --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
             --form bundle=@sonatype-bundle.zip \
-            'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC'
+            'https://central.sonatype.com/api/v1/publisher/upload'
 
   docs-and-deploy:
     needs: aggregate-and-publish

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,11 +52,11 @@ jobs:
             cd ~/.m2/repository
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
           fi
-          mv ~/m2-archive/m2-repository.zip ~/m2-archive/m2-${{ matrix.filter }}.zip
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:
-          path: ~/m2-archive/m2-${{ matrix.filter }}.zip
+          name: m2-${{ matrix.filter }}
+          path: ~/m2-archive/m2-repository.zip
           archive: false
 
   aggregate-and-publish:
@@ -90,5 +90,6 @@ jobs:
       - name: Upload Bundle to GitHub
         uses: actions/upload-artifact@v7
         with:
+          name: sonatype-bundle.zip
           path: sonatype-bundle.zip
           archive: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,11 +52,11 @@ jobs:
             cd ~/.m2/repository
             zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
           fi
+          mv ~/m2-archive/m2-repository.zip ~/m2-archive/m2-${{ matrix.filter }}.zip
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: m2-${{ matrix.filter }}
-          path: ~/m2-archive/m2-repository.zip
+          path: ~/m2-archive/m2-${{ matrix.filter }}.zip
           archive: false
 
   aggregate-and-publish:
@@ -90,6 +90,5 @@ jobs:
       - name: Upload Bundle to GitHub
         uses: actions/upload-artifact@v7
         with:
-          name: sonatype-bundle.zip
           path: sonatype-bundle.zip
           archive: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,5 @@
 name: Publish Release
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
@@ -91,3 +90,46 @@ jobs:
         with:
           name: sonatype-bundle
           path: sonatype-bundle.zip
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Sync Docs
+        run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,8 +44,12 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/m2-archive
-          cd ~/.m2/repository
-          zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            powershell -Command "Compress-Archive -Path $HOME\.m2\repository\com\episode6\redux -DestinationPath $HOME\m2-archive\m2-repository.zip"
+          else
+            cd ~/.m2/repository
+            zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
+          fi
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,10 +1,8 @@
-name: Publish Artifacts
+name: Publish Snapshot
 on:
   push:
     branches:
       - main
-    tags:
-      - '**'
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 jobs:
@@ -42,11 +40,6 @@ jobs:
         run: |
           if [ "${{ matrix.filter }}" == "macos" ]; then
             ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }}
-            if [ "${{ github.ref_type }}" == "tag" ]; then
-              SONATYPE_TOKEN=$(echo -n "${ORG_GRADLE_PROJECT_nexusUsername}:${ORG_GRADLE_PROJECT_nexusPassword}" | base64 | tr -d '\n')
-              curl -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.episode6" \
-                   -H "Authorization: Bearer ${SONATYPE_TOKEN}"
-            fi
           else
             ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }} -Pkotlin.mpp.enableMetadataPublishing=false
           fi
@@ -59,15 +52,6 @@ jobs:
       - name: Sync Docs
         if: matrix.filter == 'macos'
         run: ./gradlew syncDocs
-      - name: Deploy root docs to website
-        if: ${{ matrix.filter == 'macos' && github.ref_type == 'tag' && github.repository == 'episode6/redux-store-flow' }}
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
       - name: Deploy dokka to website
         if: ${{ matrix.filter == 'macos' && github.repository == 'episode6/redux-store-flow' }}
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.1.2 - Unreleased
 
+- Fix release publication workflow to include missing linux-x64 and windows-x64 artifacts.
+
 ## v1.1.1 - Released 06/15/2026
 
 - Fix publication failure from v1.1.0 ([711a9c2](https://github.com/episode6/redux-store-flow/commit/711a9c2803e40f5aa6feaef99193a0f473c92d45))


### PR DESCRIPTION
This PR refactors the publication process to solve the issue of multi-platform artifacts being uploaded from different IP addresses during releases.

### Changes

1.  **New `publish-release.yml`**:
    *   Triggered on tags (`v*`).
    *   Publishes artifacts to `mavenLocal` on 3 shards (Ubuntu, Windows, macOS).
    *   Aggregates shards into a single deployment bundle.
    *   Generates missing checksums.
    *   Uploads to the Sonatype Central Portal API.
    *   Handles documentation and website deployment after successful publication.

2.  **Renamed `publish-snapshot.yml`**:
    *   Renamed from `publish-artifacts.yml`.
    *   Now only triggers on pushes to `main` for snapshot publishing.
    *   Removed release-specific logic and tag triggers.