### PR TITLE
Update release skills (PR creation & No local merges)

### DIFF
--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -29,5 +29,8 @@ Create two separate Pull Requests to update versions.
     - Update `version` in `build.gradle.kts` (remove `-SNAPSHOT` if present).
     - **(VITAL)** Update `docs/CHANGELOG.md` with the release date and the final version. Ensure all changes since the last release are documented.
 
+### 4. Create Pull Requests
+- Use `gh pr create` or the GitHub UI to create the Pull Requests for the version bump branches created in step 3.
+
 ## Verification
 - After these steps, the project is ready for the "Harden Release Branch" phase, which requires manual verification and cherry-picking of bug fixes.

--- a/.agents/ship-release-skill/SKILL.md
+++ b/.agents/ship-release-skill/SKILL.md
@@ -17,7 +17,8 @@ This skill guides the agent in shipping a release branch by creating and publish
 - `release-branch-skill`: Typically run after a release branch is cut and hardened.
 
 ## Prerequisites
-- Ensure the local release branch is up-to-date by pulling from `origin` before starting the release process.
+- **Merge PRs via GitHub**: Ensure the version bump PR (and any hardening PRs) are merged via the GitHub UI or `gh pr merge`. **NEVER** use local merge commits on the release branch.
+- **Pull Latest**: Once PRs are merged on GitHub, checkout the release branch locally and pull the latest changes from `origin` to ensure the local branch is up-to-date before starting the release process.
 - **Verify Version**: The version in `build.gradle.kts` must NOT end with `-SNAPSHOT`. If it does, the release process must be aborted until the version is properly bumped.
 
 ## Quick Start


### PR DESCRIPTION
This PR updates both the release-branch-skill and ship-release-skill:
1. Adds a step to release-branch-skill for creating Pull Requests.
2. Updates ship-release-skill to mandate merging PRs via GitHub and forbids local merge commits on release branches.