### PR TITLE
Migrate publish-snapshot flow

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,7 +6,7 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 jobs:
-  publish-job:
+  build-shards:
     strategy:
       matrix:
         include:
@@ -32,28 +32,128 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Clean Project
         run: ./gradlew clean
-      - name: Generate Docs
-        if: matrix.filter == 'macos'
-        run: ./gradlew dokkaGenerateHtml
-      - name: Publish
+      - name: Publish to Maven Local
         shell: bash
-        run: |
-          if [ "${{ matrix.filter }}" == "macos" ]; then
-            ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }}
-          else
-            ./gradlew publishAllPublicationsToSonatypeRepository -Pfilter=${{ matrix.filter }} -Pkotlin.mpp.enableMetadataPublishing=false
-          fi
+        run: ./gradlew publishToMavenLocal -Pfilter=${{ matrix.filter }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASS }}
+          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
+      - name: Zip Maven Local
+        shell: bash
+        run: |
+          mkdir -p ~/m2-archive
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            cd ~/.m2/repository
+            powershell -Command "Compress-Archive -Path com -DestinationPath \$env:USERPROFILE\\m2-archive\\m2-repository.zip"
+          else
+            cd ~/.m2/repository
+            zip -r ~/m2-archive/m2-repository.zip com/episode6/redux
+          fi
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: m2-${{ matrix.filter }}
+          path: ~/m2-archive/m2-repository.zip
+          compression-level: 0
+
+  aggregate-and-publish:
+    needs: build-shards
+    runs-on: ubuntu-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: m2-zips
+      - name: Merge Artifacts
+        run: |
+          set -x
+          python3 scripts/merge-m2-shards.py --input m2-zips --output bundle || { echo "Merge script failed"; exit 1; }
+          
+          echo "Bundle content summary:"
+          find bundle -maxdepth 5 | head -n 100
+      - name: Sign and Checksum
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASS: ${{ secrets.GPG_PASS }}
+        run: |
+          set -e
+          # Import GPG key
+          echo "$GPG_KEY" | gpg --batch --import
+          
+          cd bundle
+          # Remove any existing signatures or checksums from shards
+          find . -type f \( -name "*.asc" -o -name "*.md5" -o -name "*.sha1" -o -name "*.sha256" -o -name "*.sha512" \) -delete
+
+          # Sign all artifacts (JARs, POMs, Modules, Klibs, etc.)
+          find . -type f ! -name "*.asc" ! -name "*.md5" ! -name "*.sha1" ! -name "*.sha256" ! -name "*.sha512" | while read -r file; do
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASS" --detach-sign --armor "$file" || exit 1
+          done
+
+          # Generate checksums for ALL files (including the .asc files we just created)
+          find . -type f ! -name "*.md5" ! -name "*.sha1" ! -name "*.sha256" ! -name "*.sha512" | while read -r file; do
+            echo "Generating checksums for $file"
+            for alg in md5 sha1 sha256 sha512; do
+              if [ "$alg" == "md5" ]; then
+                md5sum "$file" | cut -d ' ' -f 1 > "$file.md5" || exit 1
+              elif [ "$alg" == "sha1" ]; then
+                sha1sum "$file" | cut -d ' ' -f 1 > "$file.sha1" || exit 1
+              elif [ "$alg" == "sha256" ]; then
+                sha256sum "$file" | cut -d ' ' -f 1 > "$file.sha256" || exit 1
+              elif [ "$alg" == "sha512" ]; then
+                sha512sum "$file" | cut -d ' ' -f 1 > "$file.sha512" || exit 1
+              fi
+            done
+          done
+      - name: Create Sonatype Bundle
+        run: |
+          cd bundle
+          zip -r ../sonatype-bundle.zip .
+      - name: Upload Bundle to GitHub
+        uses: actions/upload-artifact@v7
+        with:
+          name: sonatype-bundle
+          path: sonatype-bundle.zip
+          compression-level: 0
+      - name: Publish to Sonatype Central
+        run: |
+          SONATYPE_TOKEN=$(printf "%s:%s" "${{ secrets.NEXUS_USERNAME }}" "${{ secrets.NEXUS_PASSWORD }}" | base64 | tr -d '\n')
+          curl --request POST \
+            --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
+            --form bundle=@sonatype-bundle.zip \
+            'https://central.sonatype.com/api/v1/publisher/upload'
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate Docs
+        run: ./gradlew dokkaGenerateHtml
       - name: Sync Docs
-        if: matrix.filter == 'macos'
         run: ./gradlew syncDocs
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
       - name: Deploy dokka to website
-        if: ${{ matrix.filter == 'macos' && github.repository == 'episode6/redux-store-flow' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR migrates the publish-snapshot workflow to use the same sharded aggregation methodology as the publish-release workflow. This ensures that snapshots are correctly aggregated, signed, and uploaded to the Sonatype Central Portal via the Publisher API.