### PR TITLE
Fix Dokka 2 aggregation and update docs workflow

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -165,10 +165,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Clean Project
         run: ./gradlew clean
-      - name: Generate Docs
+      - name: Generate API Docs
         run: ./gradlew dokkaGenerateHtml
-      - name: Sync Docs
-        run: ./gradlew syncDocs
+      - name: Prepare Site Docs
+        run: ./gradlew configSite
       - name: Deploy root docs to website
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:

--- a/buildSrc/src/main/groovy/plugins/ConfigSitePlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigSitePlugin.groovy
@@ -1,6 +1,7 @@
 package plugins
 
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
@@ -10,7 +11,7 @@ class ConfigSitePlugin implements Plugin<Project> {
   @Override
   void apply(Project target) {
 
-    if (target != target.rootProject) throw GradleException("Can only apply ConfigSitePlugin to root project")
+    if (target != target.rootProject) throw new GradleException("Can only apply ConfigSitePlugin to root project")
 
     target.with {
       def dokkaDir = "${rootProject.buildDir}/dokka/html"
@@ -30,6 +31,15 @@ class ConfigSitePlugin implements Plugin<Project> {
         outputDirectory.set(file(dokkaDir))
       }
 
+      dependencies {
+        subprojects.each { sub ->
+          // In Dokka 2, aggregation is done by adding subprojects as 'dokka' dependencies
+          if (sub.path != ":test-support:internal") { 
+            dokka(sub)
+          }
+        }
+      }
+
       tasks.create("copyReadmes", Copy) {
         from(file("docs/"))
         exclude(".gitignore", "_site/", "_config.yml")
@@ -41,10 +51,6 @@ class ConfigSitePlugin implements Plugin<Project> {
         doLast {
           file("$siteDir/_config.yml").write(Config.Site.generateJekyllConfig(target))
         }
-      }
-
-      tasks.create("syncDocs") {
-        dependsOn("dokkaGenerateHtml", "configSite")
       }
     }
   }


### PR DESCRIPTION
This PR fixes the Dokka 2 aggregation by adding subprojects as dependencies to the root project's Dokka task. It also removes the obsolete syncDocs task and updates the publish-artifacts workflow to use the individual tasks directly.