### PR TITLE
Modernize Gradle configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-  id("org.jetbrains.kotlin.multiplatform") version (libs.versions.kotlin.core.get()) apply (false)
-  id("org.jetbrains.kotlin.plugin.compose") version (libs.versions.kotlin.core.get()) apply (false)
-  id("org.jetbrains.dokka") version (libs.versions.dokka.core.get())
-  id("org.jetbrains.compose") version (libs.versions.compose.core.get()) apply (false)
+  alias(libs.plugins.kotlin.multiplatform) apply false
+  alias(libs.plugins.kotlin.compose) apply false
+  alias(libs.plugins.dokka)
+  alias(libs.plugins.jetbrains.compose) apply false
   id("config-site")
 }
 

--- a/buildSrc/src/main/groovy/plugins/CommonDeployablePlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/CommonDeployablePlugin.groovy
@@ -17,6 +17,14 @@ class CommonDeployablePlugin implements Plugin<Project> {
         explicitApi()
       }
 
+      dokka {
+        dokkaSourceSets.configureEach {
+          externalDocumentationLinks.register("coroutines") {
+            url.set(new URI("https://kotlinlang.org/api/kotlinx.coroutines/"))
+          }
+        }
+      }
+
       tasks.register("deploy") {
         dependsOn(tasks.named("publish"))
       }

--- a/buildSrc/src/main/groovy/plugins/CommonDeployablePlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/CommonDeployablePlugin.groovy
@@ -17,10 +17,15 @@ class CommonDeployablePlugin implements Plugin<Project> {
         explicitApi()
       }
 
-      task("deploy", dependsOn: tasks.publish)
-      task("install", dependsOn: tasks.publishToMavenLocal)
+      tasks.register("deploy") {
+        dependsOn(tasks.named("publish"))
+      }
+      tasks.register("install") {
+        dependsOn(tasks.named("publishToMavenLocal"))
+      }
 
-      task("javadocJar", type: Jar, dependsOn: "dokkaGeneratePublicationHtml") {
+      tasks.register("javadocJar", Jar) {
+        dependsOn("dokkaGeneratePublicationHtml")
         archiveClassifier.set('javadoc')
         from tasks.named("dokkaGeneratePublicationHtml")
       }

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiDeployablePlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiDeployablePlugin.groovy
@@ -17,16 +17,14 @@ class ConfigMultiDeployablePlugin implements Plugin<Project> {
 
       // mitigate gradle warnings by ensuring all pub tasks depend on all sign tasks
       def signTasks = tasks.withType(Sign)
-      tasks.withType(AbstractPublishToMaven).forEach { pubTask ->
-        signTasks.forEach {
-          pubTask.dependsOn(it)
-        }
+      tasks.withType(AbstractPublishToMaven).configureEach { pubTask ->
+        pubTask.dependsOn(signTasks)
       }
 
       publishing {
-        publications.withType(MavenPublication) {
-          Config.Maven.applyPomConfig(target, pom)
-          artifact javadocJar
+        publications.withType(MavenPublication).configureEach { pub ->
+          Config.Maven.applyPomConfig(target, pub.pom)
+          pub.artifact tasks.named("javadocJar")
         }
       }
     }

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
@@ -23,8 +23,9 @@ class ConfigMultiPlugin implements Plugin<Project> {
       kotlin {
         if (!skipTargets.contains("jvm")) {
           jvm {
+            def jvmTargetClass = it.class.classLoader.loadClass("org.jetbrains.kotlin.gradle.dsl.JvmTarget")
             compilerOptions {
-              jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(Config.Jvm.name))
+              jvmTarget.set(jvmTargetClass.fromTarget(Config.Jvm.name))
               freeCompilerArgs.add(Config.Kotlin.compilerArgs)
             }
             java {

--- a/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigMultiPlugin.groovy
@@ -23,11 +23,9 @@ class ConfigMultiPlugin implements Plugin<Project> {
       kotlin {
         if (!skipTargets.contains("jvm")) {
           jvm {
-            compilations.all {
-              kotlinOptions {
-                jvmTarget = Config.Jvm.name
-                freeCompilerArgs += Config.Kotlin.compilerArgs
-              }
+            compilerOptions {
+              jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(Config.Jvm.name))
+              freeCompilerArgs.add(Config.Kotlin.compilerArgs)
             }
             java {
               sourceCompatibility = Config.Jvm.sourceCompat
@@ -42,14 +40,12 @@ class ConfigMultiPlugin implements Plugin<Project> {
           }
         }
         if (!skipTargets.contains("js")) {
-          js(IR) {
+          js {
             nodejs()
             browser()
             binaries.library()
-            compilations.all {
-              kotlinOptions {
-                freeCompilerArgs += Config.Kotlin.compilerArgs
-              }
+            compilerOptions {
+              freeCompilerArgs.add(Config.Kotlin.compilerArgs)
             }
           }
         }
@@ -70,10 +66,8 @@ class ConfigMultiPlugin implements Plugin<Project> {
 
         for (t in Config.KMPTargets.natives - skipTargets) {
           invokeMethod(t, {
-            compilations.all {
-              kotlinOptions {
-                freeCompilerArgs += Config.Kotlin.compilerArgs
-              }
+            compilerOptions {
+              freeCompilerArgs.add(Config.Kotlin.compilerArgs)
             }
           })
         }

--- a/buildSrc/src/main/groovy/plugins/ConfigSitePlugin.groovy
+++ b/buildSrc/src/main/groovy/plugins/ConfigSitePlugin.groovy
@@ -14,42 +14,42 @@ class ConfigSitePlugin implements Plugin<Project> {
     if (target != target.rootProject) throw new GradleException("Can only apply ConfigSitePlugin to root project")
 
     target.with {
-      def dokkaDir = "${rootProject.buildDir}/dokka/html"
-      def siteDir = "${rootProject.buildDir}/site"
+      def dokkaDir = layout.buildDirectory.dir("dokka/html")
+      def siteDir = layout.buildDirectory.dir("site")
 
-      tasks.create("clearDokkaDir", Delete) {
+      tasks.register("clearDokkaDir", Delete) {
         delete(dokkaDir)
-        doLast { file(dokkaDir).mkdirs() }
+        doLast { dokkaDir.get().asFile.mkdirs() }
       }
 
-      tasks.create("clearSiteDir", Delete) {
+      tasks.register("clearSiteDir", Delete) {
         delete(siteDir)
-        doLast { file(siteDir).mkdirs() }
+        doLast { siteDir.get().asFile.mkdirs() }
       }
 
       tasks.named("dokkaGeneratePublicationHtml") {
-        outputDirectory.set(file(dokkaDir))
+        outputDirectory.set(dokkaDir)
       }
 
       dependencies {
         subprojects.each { sub ->
           // In Dokka 2, aggregation is done by adding subprojects as 'dokka' dependencies
-          if (sub.path != ":test-support:internal") { 
+          if (sub.path != ":test-support:internal") {
             dokka(sub)
           }
         }
       }
 
-      tasks.create("copyReadmes", Copy) {
+      tasks.register("copyReadmes", Copy) {
         from(file("docs/"))
         exclude(".gitignore", "_site/", "_config.yml")
-        into(file(siteDir))
+        into(siteDir)
       }
 
-      tasks.create("configSite") {
+      tasks.register("configSite") {
         dependsOn("copyReadmes")
         doLast {
-          file("$siteDir/_config.yml").write(Config.Site.generateJekyllConfig(target))
+          siteDir.get().file("_config.yml").asFile.write(Config.Site.generateJekyllConfig(target))
         }
       }
     }

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         api(libs.kotlinx.coroutines.core)
-        api(compose.runtime)
+        api(libs.compose.runtime)
         api(project(":store-flow"))
       }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.1.6 - Unreleased
 
+- Modernized Gradle configuration: replaced deprecated function calls and patterns with modern equivalents (Task Configuration Avoidance, Kotlin 2.0 `compilerOptions` DSL, and `layout.buildDirectory`).
+
 ## v1.1.5 - Released 06/18/2026
 
 - Attempting to fix site deployment issue.

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -12,6 +12,7 @@ mockk-core = "1.14.11"
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-core" }
 
 # test utils
 assertk-core = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk-core" }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -19,3 +19,9 @@ assertk-core = { module = "com.willowtreeapps.assertk:assertk", version.ref = "a
 assertk-jvm = { module = "com.willowtreeapps.assertk:assertk-jvm", version.ref = "assertk-core" }
 mockk-core = { module = "io.mockk:mockk", version.ref = "mockk-core" }
 turbine = { module = "app.cash.turbine:turbine", version = "1.2.1" }
+
+[plugins]
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin-core" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin-core" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka-core" }
+jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose-core" }

--- a/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffect.kt
+++ b/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffect.kt
@@ -4,7 +4,7 @@ import com.episode6.redux.Action
 import kotlinx.coroutines.flow.Flow
 
 /**
- * SideEffects offer a way to include managed async operations in a [StoreFlow].
+ * SideEffects offer a way to include managed async operations in a [com.episode6.redux.StoreFlow].
  * The primary input is [SideEffectContext.actions], which will receive an emission
  * for every [Action] dispatched to the Store. The SideEffect returns a new [Flow]
  * of [Action] which will subsequently be dispatched back into the Store.
@@ -20,14 +20,14 @@ public fun interface SideEffect<State : Any?> {
 public interface SideEffectContext<State: Any?> {
 
   /**
-   * A [Flow] of all the actions dispatched to the [StoreFlow]. A well-behaved
+   * A [Flow] of all the actions dispatched to the [com.episode6.redux.StoreFlow]. A well-behaved
    * SideEffect will usually filterIsInstance<SpecificAction>() then transformLatest
-   * to emit new actions back into the [StoreFlow]
+   * to emit new actions back into the [com.episode6.redux.StoreFlow]
    */
   public val actions: Flow<Action>
 
   /**
-   * Returns the current state of the [StoreFlow] at function call-time.
+   * Returns the current state of the [com.episode6.redux.StoreFlow] at function call-time.
    */
   public suspend fun currentState(): State
 }

--- a/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffectMiddleware.kt
+++ b/side-effects/src/commonMain/kotlin/com/episode6/redux/sideeffects/SideEffectMiddleware.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.launch
 
 /**
  * Returns a [Middleware] that passes actions to the supplied [sideEffects], then dispatches
- * their returned [Action]s back into the [StoreFlow]
+ * their returned [Action]s back into the [com.episode6.redux.StoreFlow]
  */
 @Suppress("FunctionName")
 public fun <State : Any?> SideEffectMiddleware(vararg sideEffects: SideEffect<State>): Middleware<State> =
@@ -16,7 +16,7 @@ public fun <State : Any?> SideEffectMiddleware(vararg sideEffects: SideEffect<St
 
 /**
  * Returns a [Middleware] that passes actions to the supplied [sideEffects], then dispatches
- * their returned [Action]s back into the [StoreFlow]
+ * their returned [Action]s back into the [com.episode6.redux.StoreFlow]
  */
 @Suppress("FunctionName")
 public fun <State : Any?> SideEffectMiddleware(sideEffects: Collection<SideEffect<State>>): Middleware<State> =


### PR DESCRIPTION
# Modernize Gradle Configuration and Fix Deprecations

This PR modernizes the Gradle build configuration across the project, replacing deprecated patterns and improving compatibility with Kotlin 2.0 and the latest Gradle APIs.

### Key Changes

*   **Task Configuration Avoidance**: Migrated from `task()` and `tasks.create()` to `tasks.register()` in all `buildSrc` plugins to improve configuration performance.
*   **Kotlin 2.0 Compiler Options**: Replaced the deprecated `kotlinOptions` DSL with the modern `compilerOptions` DSL across the KMP configuration.
*   **Gradle Layout API**: Updated site and publication plugins to use `layout.buildDirectory` instead of the deprecated `buildDir` property.
*   **Version Catalog Migration**:
    *   Moved plugin declarations to `libs.versions.toml` and updated the root `build.gradle.kts` to use `alias()` for plugin management.
    *   Updated the `compose` module to use `libs.compose.runtime` from the version catalog instead of the `compose` extension.
*   **Dokka & Documentation**:
    *   Added external documentation links for `kotlinx-coroutines` to resolve Dokka link warnings.
    *   Updated KDocs in the `side-effects` module to use fully qualified names for `StoreFlow`, ensuring correct link resolution in generated documentation.
    *   Improved the `javadocJar` task registration and publication logic.
*   **Compatibility Improvements**: Implemented a more robust way to set `jvmTarget` using reflection in `ConfigMultiPlugin.groovy` to handle `JvmTarget` class loading across different plugin environments.

### Verification Results
*   Project builds successfully with the updated Gradle configuration.
*   `CHANGELOG.md` has been updated to reflect these modernization efforts.
