### PR TITLE
Rename sonatype bundle to repo name before upload

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,5 +1,6 @@
 name: Publish Artifacts
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -150,39 +151,3 @@ jobs:
               --form bundle=@${{ github.event.repository.name }}.zip \
               'https://central.sonatype.com/api/v1/publisher/upload'
           fi
-
-  docs-and-deploy:
-    needs: aggregate-and-publish
-    runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up JDK 23
-        uses: actions/setup-java@v5
-        with:
-          java-version: '23'
-          distribution: 'zulu'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Clean Project
-        run: ./gradlew clean
-      - name: Generate API Docs
-        run: ./gradlew dokkaGenerateHtml
-      - name: Prepare Site Docs
-        run: ./gradlew configSite
-      - name: Deploy root docs to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/site
-          TARGET_FOLDER: /
-          CLEAN: false
-      - name: Deploy dokka to website
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: site
-          FOLDER: build/dokka/html
-          TARGET_FOLDER: /docs/${{ github.ref_name }}/
-          CLEAN: true

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,6 +1,5 @@
 name: Publish Artifacts
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -151,3 +150,39 @@ jobs:
               --form bundle=@${{ github.event.repository.name }}.zip \
               'https://central.sonatype.com/api/v1/publisher/upload'
           fi
+
+  docs-and-deploy:
+    needs: aggregate-and-publish
+    runs-on: macos-latest
+    if: github.repository == 'episode6/redux-store-flow'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Clean Project
+        run: ./gradlew clean
+      - name: Generate API Docs
+        run: ./gradlew dokkaGenerateHtml
+      - name: Prepare Site Docs
+        run: ./gradlew configSite
+      - name: Deploy root docs to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/site
+          TARGET_FOLDER: /
+          CLEAN: false
+      - name: Deploy dokka to website
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: build/dokka/html
+          TARGET_FOLDER: /docs/${{ github.ref_name }}/
+          CLEAN: true

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -143,10 +143,11 @@ jobs:
                 --data-binary @"$file" "$url" || { echo "Failed uploading $rel"; exit 1; }
             done
           else
+            mv sonatype-bundle.zip ${{ github.event.repository.name }}.zip
             SONATYPE_TOKEN=$(printf "%s:%s" "$NEXUS_USERNAME" "$NEXUS_PASSWORD" | base64 | tr -d '\n')
             curl --request POST \
               --header "Authorization: Bearer ${SONATYPE_TOKEN}" \
-              --form bundle=@sonatype-bundle.zip \
+              --form bundle=@${{ github.event.repository.name }}.zip \
               'https://central.sonatype.com/api/v1/publisher/upload'
           fi
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
   group = "com.episode6.redux"
-  version = "1.1.6.1"
+  version = "1.1.7-SNAPSHOT"
 }
 description = "Yet another kotlin implementation of Redux, backed by StateFlows and Coroutines"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
   group = "com.episode6.redux"
-  version = "1.1.7-SNAPSHOT"
+  version = "1.1.6.1"
 }
 description = "Yet another kotlin implementation of Redux, backed by StateFlows and Coroutines"
 


### PR DESCRIPTION
This PR updates the publish-artifacts workflow to rename the sonatype-bundle.zip to the repository name right before sending it to Sonatype Central.