### PR TITLE
Allow snapshot publication on PRs via publish-snapshot label

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -5,10 +5,13 @@ on:
       - main
     tags:
       - 'v*'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 jobs:
   build-shards:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'publish-snapshot')
     strategy:
       matrix:
         include:
@@ -63,7 +66,7 @@ jobs:
   aggregate-and-publish:
     needs: build-shards
     runs-on: ubuntu-latest
-    if: github.repository == 'episode6/redux-store-flow'
+    if: github.repository == 'episode6/redux-store-flow' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'publish-snapshot'))
     steps:
       - uses: actions/checkout@v6
       - name: Download all artifacts
@@ -126,6 +129,11 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           set -e
+          # PR-triggered runs (via the publish-snapshot label) may only publish snapshots
+          if [ "${{ github.event_name }}" == "pull_request" ] && ! find bundle -type f | grep -q -- '-SNAPSHOT'; then
+            echo "Refusing to publish a non-snapshot version from a pull request"
+            exit 1
+          fi
           # If any file path contains -SNAPSHOT treat as a snapshot and upload files individually
           if find bundle -type f | grep -q -- '-SNAPSHOT'; then
             echo "Snapshot artifacts detected — uploading files individually to maven-snapshots"
@@ -154,7 +162,7 @@ jobs:
   docs-and-deploy:
     needs: aggregate-and-publish
     runs-on: macos-latest
-    if: github.repository == 'episode6/redux-store-flow'
+    if: github.repository == 'episode6/redux-store-flow' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 23


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger (types: `opened`, `synchronize`, `reopened`, `labeled`) to `publish-artifacts.yml` so the snapshot publication flow can run on PRs.
- `build-shards` and `aggregate-and-publish` only run for PR events when the `publish-snapshot` label is present; pushes to `main` and `v*` tags behave exactly as before.
- `docs-and-deploy` is skipped entirely for PR events, so PR runs never touch the `site` branch.
- The Sonatype publish step refuses to publish from a PR if the bundle is not a `-SNAPSHOT` version, so labeling a release version-bump PR cannot accidentally publish a release.

## Notes
- Adding the `publish-snapshot` label to an open PR triggers a run immediately (via the `labeled` event); subsequent pushes to a labeled PR also publish.
- The label itself needs to be created in the repo before first use.
- Workflow-only change; `verify-docs-updated.sh` classifies workflow files as non-code, so no changelog entry is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s8pDErVG9mvJwGQJWCBDk